### PR TITLE
19 output format

### DIFF
--- a/G4SOLAr/CMakeLists.txt
+++ b/G4SOLAr/CMakeLists.txt
@@ -13,6 +13,12 @@ SET(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
 
 set(CMAKE_CONFIGURATION_TYPES Debug Release)
 
+
+if (CMAKE_BUILD_TYPE STREQUAL "Debug") 
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -g")
+  message(STATUS "DEBUG: Adding '-g' option for gdb debugging")
+endif()
+
 #----------------------------------------------------------------------------
 # Find Geant4 package, activating all available UI and Vis drivers by default
 # You can set WITH_GEANT4_UIVIS to OFF via the command line or ccmake/cmake-gui

--- a/G4SOLAr/assets/macros/electrons_backtracker.mac
+++ b/G4SOLAr/assets/macros/electrons_backtracker.mac
@@ -1,0 +1,44 @@
+######################################################################
+# @author      : Daniele Guffanti (daniele.guffanti@mib.infn.it)
+# @file        : electrons.mac
+# @created     : venerdì lug 01, 2022 11:47:12 CEST
+#
+# @description : Produce monoenergetic electrons in the detector center
+######################################################################
+
+# Set secondary production cuts for gamma and electrons
+/SLAr/phys/electronCut 0.5 mm
+/SLAr/phys/positronCut 0.5 mm
+/SLAr/phys/gammaCut 2.5 mm
+/SLAr/phys/stepMax 2.5 mm
+/SLAr/phys/DoTracePhotons true
+
+# Set particle energy and source position 
+/SLAr/gen/type ParticleGun
+/SLAr/gen/particle e-
+/SLAr/gen/energy 7 MeV
+/SLAr/gen/volume TPC11
+/SLAr/gen/SetDirectionMode isotropic
+
+# readout elements for backtracking:
+# Charge readout system: charge
+# VUV SiPM readout system: vuv_sipm
+# SuperCell: supercell
+/SLAr/manager/enableBacktracker charge 
+#/SLAr/manager/enableBacktracker vuv_sipm 
+#/SLAr/manager/enableBacktracker supercell 
+
+# available backtrackers:
+# track ID of particle responsible for the hit: trkID
+# track ID of the primary particle responsible for the hit: ancestorID
+# optical process responsible for the hit: opticalProc
+# command format: <system>:<backtracker>
+#/SLAr/manager/registerBacktracker charge:ancestorID
+/SLAr/manager/registerBacktracker charge:trkID
+#/SLAr/manager/registerBacktracker supercell:trkID
+
+# Set output file name
+#/SLAr/manager/SetOutputName electrons.root
+
+# Fire!
+/run/beamOn 20

--- a/G4SOLAr/include/SLArAnalysisManager.hh
+++ b/G4SOLAr/include/SLArAnalysisManager.hh
@@ -78,7 +78,8 @@ class SLArAnalysisManager
       return anodeCfg;}
     inline const std::map<G4String, G4double>& GetPhysicsBiasingMap() {return fBiasing;}
     inline const std::vector<SLArXSecDumpSpec>& GetXSecDumpVector() {return fXSecDump;}
-    SLArMCEventPtr* GetEvent()  {return    fMCEvent;}
+    SLArMCEventUniquePtr* GetEvent()  {return fMCEvent;}
+    SLArMCEventPtr* GetEventRecord() {return fMCEventRecord;}
     G4bool Save ();
 
     // mock fake access
@@ -105,7 +106,8 @@ class SLArAnalysisManager
 
     TFile* fRootFile;
     TTree* fEventTree;
-    SLArMCEventPtr* fMCEvent;
+    SLArMCEventPtr* fMCEventRecord;
+    SLArMCEventUniquePtr* fMCEvent;
 
     backtracker::SLArBacktrackerManager* fSuperCellBacktrackerManager;
     backtracker::SLArBacktrackerManager* fVUVSiPMBacktrackerManager;

--- a/G4SOLAr/include/SLArAnalysisManager.hh
+++ b/G4SOLAr/include/SLArAnalysisManager.hh
@@ -78,7 +78,7 @@ class SLArAnalysisManager
       return anodeCfg;}
     inline const std::map<G4String, G4double>& GetPhysicsBiasingMap() {return fBiasing;}
     inline const std::vector<SLArXSecDumpSpec>& GetXSecDumpVector() {return fXSecDump;}
-    std::unique_ptr<SLArMCEventPtr>& GetEvent()  {return    fMCEvent;}
+    SLArMCEventPtr* GetEvent()  {return    fMCEvent;}
     G4bool Save ();
 
     // mock fake access
@@ -105,7 +105,7 @@ class SLArAnalysisManager
 
     TFile* fRootFile;
     TTree* fEventTree;
-    std::unique_ptr<SLArMCEventPtr> fMCEvent;
+    SLArMCEventPtr* fMCEvent;
 
     backtracker::SLArBacktrackerManager* fSuperCellBacktrackerManager;
     backtracker::SLArBacktrackerManager* fVUVSiPMBacktrackerManager;

--- a/G4SOLAr/include/SLArAnalysisManager.hh
+++ b/G4SOLAr/include/SLArAnalysisManager.hh
@@ -50,6 +50,7 @@ class SLArAnalysisManager
 
     void   ConstructBacktracker(const G4String readout_system); 
     void   ConstructBacktracker(const backtracker::EBkTrkReadoutSystem isys); 
+    G4bool CreateEventStructure();
     G4bool CreateFileStructure();
     G4bool LoadPDSCfg         (SLArCfgSystemSuperCell*  pdsCfg );
     G4bool LoadAnodeCfg       (SLArCfgAnode*  pixCfg );
@@ -78,8 +79,7 @@ class SLArAnalysisManager
       return anodeCfg;}
     inline const std::map<G4String, G4double>& GetPhysicsBiasingMap() {return fBiasing;}
     inline const std::vector<SLArXSecDumpSpec>& GetXSecDumpVector() {return fXSecDump;}
-    SLArMCEventUniquePtr* GetEvent()  {return fMCEvent;}
-    SLArMCEventPtr* GetEventRecord() {return fMCEventRecord;}
+    SLArMCEvent* GetEvent()  {return fMCEvent;}
     G4bool Save ();
 
     // mock fake access
@@ -106,8 +106,7 @@ class SLArAnalysisManager
 
     TFile* fRootFile;
     TTree* fEventTree;
-    SLArMCEventPtr* fMCEventRecord;
-    SLArMCEventUniquePtr* fMCEvent;
+    SLArMCEvent* fMCEvent;
 
     backtracker::SLArBacktrackerManager* fSuperCellBacktrackerManager;
     backtracker::SLArBacktrackerManager* fVUVSiPMBacktrackerManager;

--- a/G4SOLAr/include/SLArAnalysisManager.hh
+++ b/G4SOLAr/include/SLArAnalysisManager.hh
@@ -78,7 +78,7 @@ class SLArAnalysisManager
       return anodeCfg;}
     inline const std::map<G4String, G4double>& GetPhysicsBiasingMap() {return fBiasing;}
     inline const std::vector<SLArXSecDumpSpec>& GetXSecDumpVector() {return fXSecDump;}
-    SLArMCEvent* GetEvent()  {return    fMCEvent;}
+    std::unique_ptr<SLArMCEventPtr>& GetEvent()  {return    fMCEvent;}
     G4bool Save ();
 
     // mock fake access
@@ -103,9 +103,9 @@ class SLArAnalysisManager
     std::map<G4String, G4double> fBiasing; 
     std::vector<SLArXSecDumpSpec> fXSecDump;
 
-    TFile*              fRootFile;
-    TTree*              fEventTree;
-    SLArMCEvent*        fMCEvent;
+    TFile* fRootFile;
+    TTree* fEventTree;
+    std::unique_ptr<SLArMCEventPtr> fMCEvent;
 
     backtracker::SLArBacktrackerManager* fSuperCellBacktrackerManager;
     backtracker::SLArBacktrackerManager* fVUVSiPMBacktrackerManager;

--- a/G4SOLAr/include/SLArAnalysisManager.hh
+++ b/G4SOLAr/include/SLArAnalysisManager.hh
@@ -86,6 +86,8 @@ class SLArAnalysisManager
     G4bool FakeAccess();
     void RegisterPhyicsBiasing(G4String particle_name, G4double biasing_factor);
     void RegisterXSecDump(const SLArXSecDumpSpec xsec_dump); 
+    inline void SetStoreTrajectoryFull(const bool store_trj_pts) {fTrajectoryFull = store_trj_pts;} 
+    inline G4bool StoreTrajectoryFull() const {return fTrajectoryFull;}
 
     SLArAnalysisManagerMsgr* fAnaMsgr;
 
@@ -101,6 +103,7 @@ class SLArAnalysisManager
     G4bool   fIsMaster;
     G4String fOutputPath;
     G4String fOutputFileName;
+    G4bool   fTrajectoryFull;
     std::map<G4String, G4double> fBiasing; 
     std::vector<SLArXSecDumpSpec> fXSecDump;
 

--- a/G4SOLAr/include/SLArAnalysisManagerMsgr.hh
+++ b/G4SOLAr/include/SLArAnalysisManagerMsgr.hh
@@ -47,6 +47,7 @@ class SLArAnalysisManagerMsgr : public G4UImessenger
     G4UIcmdWithAnInteger*       fCmdGeoAnodeDepth ; 
     G4UIcmdWithAString*         fCmdEnableBacktracker;
     G4UIcmdWithAString*         fCmdRegisterBacktracker;
+    G4UIcmdWithAnInteger*       fCmdSetZeroSuppressionThrs;
 #ifdef SLAR_GDML
     G4UIcmdWithAString*         fCmdGDMLFileName  ; 
     G4UIcmdWithAString*         fCmdGDMLExport    ;

--- a/G4SOLAr/include/SLArAnalysisManagerMsgr.hh
+++ b/G4SOLAr/include/SLArAnalysisManagerMsgr.hh
@@ -45,6 +45,7 @@ class SLArAnalysisManagerMsgr : public G4UImessenger
     G4UIcmdWithAString*         fCmdWriteCfgFile  ; 
     G4UIcmdWithAString*         fCmdPlotXSec      ; 
     G4UIcmdWithAnInteger*       fCmdGeoAnodeDepth ; 
+    G4UIcmdWithABool*           fCmdStoreFullTrajectory;
     G4UIcmdWithAString*         fCmdEnableBacktracker;
     G4UIcmdWithAString*         fCmdRegisterBacktracker;
     G4UIcmdWithAnInteger*       fCmdSetZeroSuppressionThrs;

--- a/G4SOLAr/include/SLArBacktracker.hh
+++ b/G4SOLAr/include/SLArBacktracker.hh
@@ -22,7 +22,7 @@ enum EBkTrkReadoutSystem {kNoSystem = -1, kCharge = 0, kVUVSiPM = 1, kSuperCell 
 extern const G4String BkTrkReadoutSystemTag[3]; 
 EBkTrkReadoutSystem GetBacktrackerReadoutSystem(const G4String sys);
 
-enum EBacktracker {kNoBacktracker = -1, kTrkID = 0, kAnchestorID = 1, kOpticalProc = 2};
+enum EBacktracker {kNoBacktracker = -1, kTrkID = 0, kAncestorID = 1, kOpticalProc = 2};
 extern const G4String BacktrackerLabel[3];
 EBacktracker GetBacktrackerEnum(const G4String bkt);
 

--- a/G4SOLAr/include/SLArUserTrackInformation.hh
+++ b/G4SOLAr/include/SLArUserTrackInformation.hh
@@ -13,8 +13,8 @@
 
 class SLArUserTrackInformation : public G4VUserTrackInformation {
   public: 
-    SLArUserTrackInformation(); 
-    SLArUserTrackInformation(const G4String& infoType); 
+    SLArUserTrackInformation(SLArEventTrajectory* trj); 
+    SLArUserTrackInformation(SLArEventTrajectory* trj, const G4String& infoType); 
     SLArUserTrackInformation(const SLArUserTrackInformation& info); 
     inline virtual ~SLArUserTrackInformation() {}; 
 
@@ -24,7 +24,7 @@ class SLArUserTrackInformation : public G4VUserTrackInformation {
     inline void MakeTrajectory(); 
 
     inline void SetStoreTrajectory(const G4bool doStore) {fStoreTrajectory = doStore;}
-    inline void SetTrajectory(SLArEventTrajectory* trajectory) {fTrajectory = trajectory;} 
+    inline void SetTrajectory(SLArEventTrajectory& trajectory) {fTrajectory = &trajectory;} 
 
   private:
     SLArEventTrajectory* fTrajectory;

--- a/G4SOLAr/include/config/SLArCfgAnode.hh
+++ b/G4SOLAr/include/config/SLArCfgAnode.hh
@@ -22,7 +22,8 @@ class SLArCfgAnode : public SLArCfgAssembly<SLArCfgMegaTile> {
     ~SLArCfgAnode(); 
 
     TH2Poly* ConstructPixHistMap(const int depth, const std::vector<int>); 
-    SLArPixIdxCoord FindPixel(double x, double y); 
+    SLArPixIdxCoord GetPixelBinCoord(const double& x, const double& y); 
+    SLArPixIdxCoord GetPixelCoord(const double& x, const double& y); 
     void RegisterMap(size_t ilevel, TH2Poly* hmap); 
     inline TH2Poly* GetAnodeMap(size_t ilevel) {return fAnodeLevelsMap.find(ilevel)->second;}
     inline int GetTPCID() const {return fTPCID;}

--- a/G4SOLAr/include/config/SLArCfgAssembly.hh
+++ b/G4SOLAr/include/config/SLArCfgAssembly.hh
@@ -35,7 +35,7 @@ class SLArCfgAssembly : public SLArCfgBaseModule {
     inline const std::map<int, TBaseModule*>& GetConstMap() const {return fElementsMap;}
     void RegisterElement(TBaseModule* element);
     virtual TH2Poly* BuildPolyBinHist(ESubModuleReferenceFrame kFrame = kWorld, int n = 25, int m = 25);
-    TGraph* BuildGShape() override; 
+    TGraph BuildGShape() override; 
 
   protected: 
     int fNElements; 

--- a/G4SOLAr/include/config/SLArCfgBaseModule.hh
+++ b/G4SOLAr/include/config/SLArCfgBaseModule.hh
@@ -60,7 +60,7 @@ class SLArCfgBaseModule : public TNamed {
     inline void   SetSize (const float x, const float y, const float z) { fSize = TVector3(x, y, z); }
 
     inline TVector3 GetNormal() const {return fNormal;}
-    virtual TGraph* BuildGShape() {return nullptr;} 
+    virtual TGraph BuildGShape()=0; 
     inline void SetupAxis0( const TVector3 v) {fAxis0 = v;} 
     inline void SetupAxis1( const TVector3 v) {fAxis1 = v;}
     inline void SetupAxes ( const TVector3 v0, const TVector3 v1 ) {fAxis0 = v0; fAxis1 = v1;}

--- a/G4SOLAr/include/config/SLArCfgBaseSystem.hh
+++ b/G4SOLAr/include/config/SLArCfgBaseSystem.hh
@@ -33,7 +33,8 @@ class SLArCfgBaseSystem : public SLArCfgBaseModule
     TAssemblyModule* GetBaseElement(const char* name);
     TAssemblyModule* FindBaseElementInMap(int ibin); 
     std::map<int, TAssemblyModule*>& GetMap() {return fElementsMap;}
-    void RegisterElement(TAssemblyModule* mod); 
+    void RegisterElement(TAssemblyModule* mod);
+    TGraph BuildGShape() override;
 
   protected:
     int fNElements; 

--- a/G4SOLAr/include/config/SLArCfgReadoutTile.hh
+++ b/G4SOLAr/include/config/SLArCfgReadoutTile.hh
@@ -31,7 +31,7 @@ class SLArCfgReadoutTile : public SLArCfgBaseModule
     void   Set2DSize_X(float _x) {f2DSize_X = _x;}
     void   Set2DSize_Y(float _y) {f2DSize_Y = _y;}
     void   DumpInfo() override;
-    TGraph* BuildGShape() override;
+    TGraph BuildGShape() override;
     // TODO: Move this method in a more appropriate place
     //void   AddPixelToHistMap(TH2Poly* hmap, std::vector<xypoint>);
     // TODO: Move this method in SLArCfgSystemPix

--- a/G4SOLAr/include/config/SLArCfgSuperCell.hh
+++ b/G4SOLAr/include/config/SLArCfgSuperCell.hh
@@ -22,7 +22,7 @@ class SLArCfgSuperCell : public SLArCfgBaseModule
     ~SLArCfgSuperCell();
 
     void   DumpInfo() override;
-    TGraph* BuildGShape() override;
+    TGraph BuildGShape() override;
 
   protected:
 

--- a/G4SOLAr/include/config/SLArCfgSuperCellArray.hh
+++ b/G4SOLAr/include/config/SLArCfgSuperCellArray.hh
@@ -24,7 +24,7 @@ class SLArCfgSuperCellArray : public SLArCfgAssembly<SLArCfgSuperCell> {
 
     void DumpMap(); 
 
-    ClassDefOverride(SLArCfgSuperCellArray, 1);
+    ClassDefOverride(SLArCfgSuperCellArray, 2);
 };
 
 #endif /* end of include guard SLARCFGSUPERCELLARRAY_HH */

--- a/G4SOLAr/include/event/SLArEventAnode.hh
+++ b/G4SOLAr/include/event/SLArEventAnode.hh
@@ -13,6 +13,7 @@
 #include "config/SLArCfgMegaTile.hh"
 #include "event/SLArEventMegatile.hh"
 
+template<class M, class T, class P>
 class SLArEventAnode : public TNamed {
   public:
     SLArEventAnode(); 
@@ -21,13 +22,14 @@ class SLArEventAnode : public TNamed {
     ~SLArEventAnode(); 
 
     int ConfigSystem(SLArCfgAnode* cfg);
-    SLArEventMegatile* CreateEventMegatile(const int mtIdx); 
-    inline std::map<int, SLArEventMegatile*>& GetMegaTilesMap() {return fMegaTilesMap;}
-    inline const std::map<int, SLArEventMegatile*>& GetConstMegaTilesMap() const {return fMegaTilesMap;}
-    inline int GetNhits() {return fNhits;}
-    inline bool IsActive() {return fIsActive;}
+    M& GetOrCreateEventMegatile(const int mtIdx); 
+    inline std::map<int, M>& GetMegaTilesMap() {return fMegaTilesMap;}
+    inline const std::map<int, M>& GetConstMegaTilesMap() const {return fMegaTilesMap;}
+    inline int GetNhits() const {return fNhits;}
+    inline bool IsActive() const {return fIsActive;}
 
-    SLArEventTile* RegisterHit(SLArEventPhotonHit* hit); 
+    T& RegisterHit(const SLArEventPhotonHit& hit); 
+    P& RegisterChargeHit(const SLArCfgAnode::SLArPixIdxCoord& pixId, const SLArEventChargeHit& hit); 
     int ResetHits(); 
 
     void SetActive(bool is_active); 
@@ -46,12 +48,14 @@ class SLArEventAnode : public TNamed {
     bool fIsActive;
     UShort_t fLightBacktrackerRecordSize;
     UShort_t fChargeBacktrackerRecordSize;
-    std::map<int, SLArEventMegatile*> fMegaTilesMap;
+    std::map<int, M> fMegaTilesMap;
 
   public:
-    ClassDef(SLArEventAnode, 1)
+    ClassDef(SLArEventAnode, 2)
 };
 
+typedef SLArEventAnode<std::unique_ptr<SLArEventMegatileUniquePtr>, std::unique_ptr<SLArEventTileUniquePtr>, std::unique_ptr<SLArEventChargePixel>> SLArEventAnodeUniquePtr;
+typedef SLArEventAnode<SLArEventMegatilePtr*, SLArEventTilePtr*, SLArEventChargePixel*> SLArEventAnodePtr;
 
 #endif /* end of include guard SLArEventAnode_HH */
 

--- a/G4SOLAr/include/event/SLArEventAnode.hh
+++ b/G4SOLAr/include/event/SLArEventAnode.hh
@@ -37,6 +37,11 @@ class SLArEventAnode : public TNamed {
     inline UShort_t GetChargeBacktrackerRecordSize() const {return fChargeBacktrackerRecordSize;}
     inline void SetLightBacktrackerRecordSize(const UShort_t size) {fLightBacktrackerRecordSize = size;}
     inline UShort_t GetLightBacktrackerRecordSize() const {return fLightBacktrackerRecordSize;}
+    inline void SetZeroSuppressionThreshold(const UShort_t& threshold) {fZeroSuppressionThreshold = threshold;}
+    inline UShort_t GetZeroSuppressionThreshold() const {return fZeroSuppressionThreshold;}
+
+    Int_t ApplyZeroSuppression(); 
+
     //bool SortHits(); 
 
     inline void SetID(const int anode_id) {fID = anode_id;}
@@ -48,6 +53,7 @@ class SLArEventAnode : public TNamed {
     bool fIsActive;
     UShort_t fLightBacktrackerRecordSize;
     UShort_t fChargeBacktrackerRecordSize;
+    UShort_t fZeroSuppressionThreshold;
     std::map<int, SLArEventMegatile> fMegaTilesMap;
 
   public:

--- a/G4SOLAr/include/event/SLArEventAnode.hh
+++ b/G4SOLAr/include/event/SLArEventAnode.hh
@@ -21,6 +21,9 @@ class SLArEventAnode : public TNamed {
     SLArEventAnode(const SLArEventAnode&);
     ~SLArEventAnode(); 
 
+    template<class N, class U, class Q>
+    void SoftCopy(SLArEventAnode<N, U, Q>& record) const;
+
     int ConfigSystem(SLArCfgAnode* cfg);
     M& GetOrCreateEventMegatile(const int mtIdx); 
     inline std::map<int, M>& GetMegaTilesMap() {return fMegaTilesMap;}
@@ -31,6 +34,7 @@ class SLArEventAnode : public TNamed {
     T& RegisterHit(const SLArEventPhotonHit& hit); 
     P& RegisterChargeHit(const SLArCfgAnode::SLArPixIdxCoord& pixId, const SLArEventChargeHit& hit); 
     int ResetHits(); 
+    int SoftResetHits();
 
     void SetActive(bool is_active); 
     inline void SetChargeBacktrackerRecordSize(const UShort_t size) {fChargeBacktrackerRecordSize = size;}

--- a/G4SOLAr/include/event/SLArEventAnode.hh
+++ b/G4SOLAr/include/event/SLArEventAnode.hh
@@ -13,7 +13,6 @@
 #include "config/SLArCfgMegaTile.hh"
 #include "event/SLArEventMegatile.hh"
 
-template<class M, class T, class P>
 class SLArEventAnode : public TNamed {
   public:
     SLArEventAnode(); 
@@ -21,18 +20,15 @@ class SLArEventAnode : public TNamed {
     SLArEventAnode(const SLArEventAnode&);
     ~SLArEventAnode(); 
 
-    template<class N, class U, class Q>
-    void SoftCopy(SLArEventAnode<N, U, Q>& record) const;
-
     int ConfigSystem(SLArCfgAnode* cfg);
-    M& GetOrCreateEventMegatile(const int mtIdx); 
-    inline std::map<int, M>& GetMegaTilesMap() {return fMegaTilesMap;}
-    inline const std::map<int, M>& GetConstMegaTilesMap() const {return fMegaTilesMap;}
+    SLArEventMegatile* GetOrCreateEventMegatile(const int mtIdx); 
+    inline std::map<int, SLArEventMegatile*>& GetMegaTilesMap() {return fMegaTilesMap;}
+    inline const std::map<int, SLArEventMegatile*>& GetConstMegaTilesMap() const {return fMegaTilesMap;}
     inline int GetNhits() const {return fNhits;}
     inline bool IsActive() const {return fIsActive;}
 
-    T& RegisterHit(const SLArEventPhotonHit& hit); 
-    P& RegisterChargeHit(const SLArCfgAnode::SLArPixIdxCoord& pixId, const SLArEventChargeHit& hit); 
+    SLArEventTile* RegisterHit(const SLArEventPhotonHit& hit); 
+    SLArEventChargePixel* RegisterChargeHit(const SLArCfgAnode::SLArPixIdxCoord& pixId, const SLArEventChargeHit& hit); 
     int ResetHits(); 
     int SoftResetHits();
 
@@ -52,14 +48,11 @@ class SLArEventAnode : public TNamed {
     bool fIsActive;
     UShort_t fLightBacktrackerRecordSize;
     UShort_t fChargeBacktrackerRecordSize;
-    std::map<int, M> fMegaTilesMap;
+    std::map<int, SLArEventMegatile*> fMegaTilesMap;
 
   public:
     ClassDef(SLArEventAnode, 2)
 };
-
-typedef SLArEventAnode<std::unique_ptr<SLArEventMegatileUniquePtr>, std::unique_ptr<SLArEventTileUniquePtr>, std::unique_ptr<SLArEventChargePixel>> SLArEventAnodeUniquePtr;
-typedef SLArEventAnode<SLArEventMegatilePtr*, SLArEventTilePtr*, SLArEventChargePixel*> SLArEventAnodePtr;
 
 #endif /* end of include guard SLArEventAnode_HH */
 

--- a/G4SOLAr/include/event/SLArEventAnode.hh
+++ b/G4SOLAr/include/event/SLArEventAnode.hh
@@ -21,14 +21,14 @@ class SLArEventAnode : public TNamed {
     ~SLArEventAnode(); 
 
     int ConfigSystem(SLArCfgAnode* cfg);
-    SLArEventMegatile* GetOrCreateEventMegatile(const int mtIdx); 
-    inline std::map<int, SLArEventMegatile*>& GetMegaTilesMap() {return fMegaTilesMap;}
-    inline const std::map<int, SLArEventMegatile*>& GetConstMegaTilesMap() const {return fMegaTilesMap;}
+    SLArEventMegatile& GetOrCreateEventMegatile(const int mtIdx); 
+    inline std::map<int, SLArEventMegatile>& GetMegaTilesMap() {return fMegaTilesMap;}
+    inline const std::map<int, SLArEventMegatile>& GetConstMegaTilesMap() const {return fMegaTilesMap;}
     inline int GetNhits() const {return fNhits;}
     inline bool IsActive() const {return fIsActive;}
 
-    SLArEventTile* RegisterHit(const SLArEventPhotonHit& hit); 
-    SLArEventChargePixel* RegisterChargeHit(const SLArCfgAnode::SLArPixIdxCoord& pixId, const SLArEventChargeHit& hit); 
+    SLArEventTile& RegisterHit(const SLArEventPhotonHit& hit); 
+    SLArEventChargePixel& RegisterChargeHit(const SLArCfgAnode::SLArPixIdxCoord& pixId, const SLArEventChargeHit& hit); 
     int ResetHits(); 
     int SoftResetHits();
 
@@ -48,7 +48,7 @@ class SLArEventAnode : public TNamed {
     bool fIsActive;
     UShort_t fLightBacktrackerRecordSize;
     UShort_t fChargeBacktrackerRecordSize;
-    std::map<int, SLArEventMegatile*> fMegaTilesMap;
+    std::map<int, SLArEventMegatile> fMegaTilesMap;
 
   public:
     ClassDef(SLArEventAnode, 2)

--- a/G4SOLAr/include/event/SLArEventChargeHit.hh
+++ b/G4SOLAr/include/event/SLArEventChargeHit.hh
@@ -13,15 +13,13 @@
 class SLArEventChargeHit : public SLArEventGenericHit {
   public: 
     SLArEventChargeHit(); 
-    SLArEventChargeHit(float time, int trkId, int primaryID); 
+    SLArEventChargeHit(float time, int trkId=-1, int primaryID=-1);
     SLArEventChargeHit(const SLArEventChargeHit& h);
     ~SLArEventChargeHit() {}; 
 
     void   DumpInfo(); 
 
   private:
-    int    fTrkID;
-    int    fPrimaryID; 
 
   public: 
     ClassDef(SLArEventChargeHit, 1);

--- a/G4SOLAr/include/event/SLArEventChargePixel.hh
+++ b/G4SOLAr/include/event/SLArEventChargePixel.hh
@@ -18,7 +18,7 @@
 class SLArEventChargePixel : public SLArEventHitsCollection<SLArEventChargeHit> {
   public: 
     SLArEventChargePixel(); 
-    SLArEventChargePixel(const int, const SLArEventChargeHit*); 
+    SLArEventChargePixel(const int&, const SLArEventChargeHit&); 
     SLArEventChargePixel(const SLArEventChargePixel&); 
     ~SLArEventChargePixel() {}
 

--- a/G4SOLAr/include/event/SLArEventGenericHit.hh
+++ b/G4SOLAr/include/event/SLArEventGenericHit.hh
@@ -16,6 +16,7 @@
 class SLArEventGenericHit : public TObject {
   public: 
     SLArEventGenericHit(); 
+    SLArEventGenericHit(float t, int prodTrkID=-1, int primaryTrkID=-1);
     SLArEventGenericHit(const SLArEventGenericHit& h); 
     virtual ~SLArEventGenericHit() {}
 

--- a/G4SOLAr/include/event/SLArEventHitsCollection.hh
+++ b/G4SOLAr/include/event/SLArEventHitsCollection.hh
@@ -27,6 +27,8 @@ class SLArEventHitsCollection : public TNamed {
     SLArEventHitsCollection(const SLArEventHitsCollection&); 
     virtual ~SLArEventHitsCollection(); 
 
+    void Copy(SLArEventHitsCollection& record) const;
+
     template<typename TT>
     UShort_t ConvertToClock(const TT& val) {return static_cast<UShort_t>(val / fClockUnit);}
     inline UShort_t GetClockUnit() const {return fClockUnit;}
@@ -52,6 +54,7 @@ class SLArEventHitsCollection : public TNamed {
     inline void SetIdx(int idx) {fIdx = idx;}
     inline void SetClockUnit(const UShort_t unit) {fClockUnit = unit;}
     inline void SetBacktrackerRecordSize(const UShort_t size) {fBacktrackerRecordSize = size;}
+    inline void SetNhits(const int& n) {fNhits = n;}
 
   protected:
     int fIdx; 

--- a/G4SOLAr/include/event/SLArEventHitsCollection.hh
+++ b/G4SOLAr/include/event/SLArEventHitsCollection.hh
@@ -30,8 +30,8 @@ class SLArEventHitsCollection : public TNamed {
     template<typename TT>
     UShort_t ConvertToClock(const TT& val) {return static_cast<UShort_t>(val / fClockUnit);}
     inline UShort_t GetClockUnit() const {return fClockUnit;}
-    inline int GetIdx() {return fIdx;}
-    inline int GetNhits() {return fNhits;}
+    inline int GetIdx() const {return fIdx;}
+    inline int GetNhits() const {return fNhits;}
     inline virtual double GetTime() {return -1.;} 
     inline HitsCollection_t& GetHits() {return fHits;}
     inline const HitsCollection_t& GetConstHits() const {return fHits;}
@@ -40,11 +40,11 @@ class SLArEventHitsCollection : public TNamed {
 
     inline UShort_t GetBacktrackerRecordSize() const {return fBacktrackerRecordSize;}
     SLArEventBacktrackerVector* GetBacktrackerVector(UShort_t key); 
-    inline bool IsActive() {return fIsActive;}
+    inline bool IsActive() const {return fIsActive;} 
 
-    virtual void PrintHits(); 
+    virtual void PrintHits() const; 
 
-    virtual int RegisterHit(const T* hit); 
+    virtual int RegisterHit(const T hit); 
     virtual int ResetHits(); 
 
     //virtual bool SortHits(); 

--- a/G4SOLAr/include/event/SLArEventHitsCollection.hh
+++ b/G4SOLAr/include/event/SLArEventHitsCollection.hh
@@ -56,6 +56,8 @@ class SLArEventHitsCollection : public TNamed {
     inline void SetBacktrackerRecordSize(const UShort_t size) {fBacktrackerRecordSize = size;}
     inline void SetNhits(const int& n) {fNhits = n;}
 
+    int ZeroSuppression(const UShort_t threshold);  
+
   protected:
     int fIdx; 
     bool fIsActive; 

--- a/G4SOLAr/include/event/SLArEventHitsCollection.hh
+++ b/G4SOLAr/include/event/SLArEventHitsCollection.hh
@@ -41,7 +41,7 @@ class SLArEventHitsCollection : public TNamed {
     inline const BacktrackerVectorCollection_t& GetBacktrackerRecordCollection() const {return fBacktrackerCollections;}
 
     inline UShort_t GetBacktrackerRecordSize() const {return fBacktrackerRecordSize;}
-    SLArEventBacktrackerVector* GetBacktrackerVector(UShort_t key); 
+    SLArEventBacktrackerVector& GetBacktrackerVector(UShort_t key); 
     inline bool IsActive() const {return fIsActive;} 
 
     virtual void PrintHits() const; 

--- a/G4SOLAr/include/event/SLArEventMegatile.hh
+++ b/G4SOLAr/include/event/SLArEventMegatile.hh
@@ -7,11 +7,14 @@
 #ifndef SLAREVENTMEGATILE_HH
 
 #define SLAREVENTMEGATILE_HH
+#include <map>
+#include <memory>
 
 #include "event/SLArEventTile.hh"
 #include "config/SLArCfgMegaTile.hh"
 #include "config/SLArCfgReadoutTile.hh"
 
+template<class T>
 class SLArEventMegatile : public TNamed {
   public: 
     SLArEventMegatile(); 
@@ -19,16 +22,16 @@ class SLArEventMegatile : public TNamed {
     SLArEventMegatile(const SLArEventMegatile& right);
     ~SLArEventMegatile(); 
 
-    SLArEventTile* CreateEventTile(const int tileIdx); 
+    T& GetOrCreateEventTile(const int& tileIdx); 
     int ConfigModule(const SLArCfgMegaTile* cfg);
 
-    inline const std::map<int, SLArEventTile*>& GetConstTileMap() const {return fTilesMap;}
-    inline std::map<int, SLArEventTile*>& GetTileMap() {return fTilesMap;}
+    inline const std::map<int, T>& GetConstTileMap() const {return fTilesMap;}
+    inline std::map<int, T>& GetTileMap() {return fTilesMap;}
     int GetNPhotonHits() const;
     int GetNChargeHits() const; 
     inline int GetIdx() const {return fIdx;}
 
-    SLArEventTile* RegisterHit(SLArEventPhotonHit* hit); 
+    T& RegisterHit(const SLArEventPhotonHit& hit); 
     int ResetHits(); 
 
     void SetActive(bool is_active); 
@@ -45,12 +48,14 @@ class SLArEventMegatile : public TNamed {
     int fNhits; 
     UShort_t fLightBacktrackerRecordSize;
     UShort_t fChargeBacktrackerRecordSize;
-    std::map<int, SLArEventTile*> fTilesMap; 
+    std::map<int, T> fTilesMap; 
 
   public:
-    ClassDef(SLArEventMegatile, 1)
+    ClassDef(SLArEventMegatile, 2)
 };
 
+typedef SLArEventMegatile<SLArEventTilePtr*> SLArEventMegatilePtr;
+typedef SLArEventMegatile<std::unique_ptr<SLArEventTileUniquePtr>> SLArEventMegatileUniquePtr;
 
 #endif /* end of include guard SLAREVENTMEGATILE_HH */
 

--- a/G4SOLAr/include/event/SLArEventMegatile.hh
+++ b/G4SOLAr/include/event/SLArEventMegatile.hh
@@ -14,7 +14,6 @@
 #include "config/SLArCfgMegaTile.hh"
 #include "config/SLArCfgReadoutTile.hh"
 
-template<class T>
 class SLArEventMegatile : public TNamed {
   public: 
     SLArEventMegatile(); 
@@ -22,19 +21,16 @@ class SLArEventMegatile : public TNamed {
     SLArEventMegatile(const SLArEventMegatile& right);
     ~SLArEventMegatile(); 
 
-    template<class R>
-    void SoftCopy(SLArEventMegatile<R>& record) const; 
-
-    T& GetOrCreateEventTile(const int& tileIdx); 
+    SLArEventTile* GetOrCreateEventTile(const int& tileIdx); 
     int ConfigModule(const SLArCfgMegaTile* cfg);
 
-    inline const std::map<int, T>& GetConstTileMap() const {return fTilesMap;}
-    inline std::map<int, T>& GetTileMap() {return fTilesMap;}
+    inline const std::map<int, SLArEventTile*>& GetConstTileMap() const {return fTilesMap;}
+    inline std::map<int, SLArEventTile*>& GetTileMap() {return fTilesMap;}
     int GetNPhotonHits() const;
     int GetNChargeHits() const; 
     inline int GetIdx() const {return fIdx;}
 
-    T& RegisterHit(const SLArEventPhotonHit& hit); 
+    SLArEventTile* RegisterHit(const SLArEventPhotonHit& hit); 
     int ResetHits(); 
     int SoftResetHits();
 
@@ -52,14 +48,11 @@ class SLArEventMegatile : public TNamed {
     int fNhits; 
     UShort_t fLightBacktrackerRecordSize;
     UShort_t fChargeBacktrackerRecordSize;
-    std::map<int, T> fTilesMap; 
+    std::map<int, SLArEventTile*> fTilesMap; 
 
   public:
     ClassDef(SLArEventMegatile, 2)
 };
-
-typedef SLArEventMegatile<SLArEventTilePtr*> SLArEventMegatilePtr;
-typedef SLArEventMegatile<std::unique_ptr<SLArEventTileUniquePtr>> SLArEventMegatileUniquePtr;
 
 #endif /* end of include guard SLAREVENTMEGATILE_HH */
 

--- a/G4SOLAr/include/event/SLArEventMegatile.hh
+++ b/G4SOLAr/include/event/SLArEventMegatile.hh
@@ -21,16 +21,16 @@ class SLArEventMegatile : public TNamed {
     SLArEventMegatile(const SLArEventMegatile& right);
     ~SLArEventMegatile(); 
 
-    SLArEventTile* GetOrCreateEventTile(const int& tileIdx); 
+    SLArEventTile& GetOrCreateEventTile(const int& tileIdx); 
     int ConfigModule(const SLArCfgMegaTile* cfg);
 
-    inline const std::map<int, SLArEventTile*>& GetConstTileMap() const {return fTilesMap;}
-    inline std::map<int, SLArEventTile*>& GetTileMap() {return fTilesMap;}
+    inline const std::map<int, SLArEventTile>& GetConstTileMap() const {return fTilesMap;}
+    inline std::map<int, SLArEventTile>& GetTileMap() {return fTilesMap;}
     int GetNPhotonHits() const;
     int GetNChargeHits() const; 
     inline int GetIdx() const {return fIdx;}
 
-    SLArEventTile* RegisterHit(const SLArEventPhotonHit& hit); 
+    SLArEventTile& RegisterHit(const SLArEventPhotonHit& hit); 
     int ResetHits(); 
     int SoftResetHits();
 
@@ -48,7 +48,7 @@ class SLArEventMegatile : public TNamed {
     int fNhits; 
     UShort_t fLightBacktrackerRecordSize;
     UShort_t fChargeBacktrackerRecordSize;
-    std::map<int, SLArEventTile*> fTilesMap; 
+    std::map<int, SLArEventTile> fTilesMap; 
 
   public:
     ClassDef(SLArEventMegatile, 2)

--- a/G4SOLAr/include/event/SLArEventMegatile.hh
+++ b/G4SOLAr/include/event/SLArEventMegatile.hh
@@ -22,6 +22,9 @@ class SLArEventMegatile : public TNamed {
     SLArEventMegatile(const SLArEventMegatile& right);
     ~SLArEventMegatile(); 
 
+    template<class R>
+    void SoftCopy(SLArEventMegatile<R>& record) const; 
+
     T& GetOrCreateEventTile(const int& tileIdx); 
     int ConfigModule(const SLArCfgMegaTile* cfg);
 
@@ -33,6 +36,7 @@ class SLArEventMegatile : public TNamed {
 
     T& RegisterHit(const SLArEventPhotonHit& hit); 
     int ResetHits(); 
+    int SoftResetHits();
 
     void SetActive(bool is_active); 
     void SetIdx(int idx) {fIdx = idx;}

--- a/G4SOLAr/include/event/SLArEventReadoutLinkDef.h
+++ b/G4SOLAr/include/event/SLArEventReadoutLinkDef.h
@@ -26,31 +26,15 @@
 #pragma link C++ class SLArEventHitsCollection<SLArEventPhotonHit>++;
 #pragma link C++ class SLArEventHitsCollection<SLArEventChargeHit>++;
 #pragma link C++ class SLArEventChargePixel++; 
-#pragma link C++ class std::map<int, std::unique_ptr<SLArEventChargePixel>>++; 
 #pragma link C++ class std::map<int, SLArEventChargePixel*>++; 
-#pragma link C++ class SLArEventTile<std::unique_ptr<SLArEventChargePixel>>++;
-#pragma link C++ class SLArEventTile<SLArEventChargePixel*>++;
-#pragma link C++ typedef SLArEventTilePtr++;
-#pragma link C++ typedef SLArEventTileUniquePtr++;
-#pragma link C++ class std::map<int, std::unique_ptr<SLArEventTileUniquePtr>>++;
-#pragma link C++ class std::map<int, SLArEventTilePtr*>++;
-#pragma link C++ class SLArEventMegatile<std::unique_ptr<SLArEventTileUniquePtr>>++;
-#pragma link C++ class SLArEventMegatile<SLArEventTilePtr*>++;
-#pragma link C++ typedef SLArEventMegatilePtr++;
-#pragma link C++ typedef SLArEventMegatileUniquePtr++;
-#pragma link C++ class std::map<int, std::unique_ptr<SLArEventMegatileUniquePtr>>++;
-#pragma link C++ class std::map<int, SLArEventMegatilePtr*>++;
-#pragma link C++ class SLArEventAnode<std::unique_ptr<SLArEventMegatileUniquePtr>, std::unique_ptr<SLArEventTileUniquePtr>, std::unique_ptr<SLArEventChargePixel>>++;
-#pragma link C++ class SLArEventAnode<SLArEventMegatilePtr*, SLArEventTilePtr*, SLArEventChargePixel*>++;
-#pragma link C++ typedef SLArEventAnodePtr++;
-#pragma link C++ typedef SLArEventAnodeUniquePtr++;
+#pragma link C++ class SLArEventTile++;
+#pragma link C++ class std::map<int, SLArEventTile*>++;
+#pragma link C++ class SLArEventMegatile++;
+#pragma link C++ class std::map<int, SLArEventMegatile*>++;
+#pragma link C++ class SLArEventAnode++;
 #pragma link C++ class SLArEventSuperCell++;
-#pragma link C++ class std::map<int, std::unique_ptr<SLArEventSuperCell>>++;
 #pragma link C++ class std::map<int, SLArEventSuperCell*>++;
-#pragma link C++ class SLArEventSuperCellArray<std::unique_ptr<SLArEventSuperCell>>++;
-#pragma link C++ class SLArEventSuperCellArray<SLArEventSuperCell*>++;
-#pragma link C++ typedef SLArEventSuperCellArrayPtr++;
-#pragma link C++ typedef SLArEventSuperCellArrayUniquePtr++;
+#pragma link C++ class SLArEventSuperCellArray++;
 
 #endif
 

--- a/G4SOLAr/include/event/SLArEventReadoutLinkDef.h
+++ b/G4SOLAr/include/event/SLArEventReadoutLinkDef.h
@@ -26,14 +26,14 @@
 #pragma link C++ class SLArEventHitsCollection<SLArEventPhotonHit>++;
 #pragma link C++ class SLArEventHitsCollection<SLArEventChargeHit>++;
 #pragma link C++ class SLArEventChargePixel++; 
-#pragma link C++ class std::map<int, SLArEventChargePixel*>++; 
+#pragma link C++ class std::map<int, SLArEventChargePixel>++; 
 #pragma link C++ class SLArEventTile++;
-#pragma link C++ class std::map<int, SLArEventTile*>++;
+#pragma link C++ class std::map<int, SLArEventTile>++;
 #pragma link C++ class SLArEventMegatile++;
-#pragma link C++ class std::map<int, SLArEventMegatile*>++;
+#pragma link C++ class std::map<int, SLArEventMegatile>++;
 #pragma link C++ class SLArEventAnode++;
 #pragma link C++ class SLArEventSuperCell++;
-#pragma link C++ class std::map<int, SLArEventSuperCell*>++;
+#pragma link C++ class std::map<int, SLArEventSuperCell>++;
 #pragma link C++ class SLArEventSuperCellArray++;
 
 #endif

--- a/G4SOLAr/include/event/SLArEventReadoutLinkDef.h
+++ b/G4SOLAr/include/event/SLArEventReadoutLinkDef.h
@@ -12,8 +12,8 @@
 #pragma link C++ class SLArEventGenericHit++; 
 #pragma link C++ class SLArEventPhotonHit++; 
 #pragma link C++ class SLArEventChargeHit++; 
-#pragma link C++ class std::vector<SLArEventChargeHit*>++; 
-#pragma link C++ class std::vector<SLArEventPhotonHit*>++;
+#pragma link C++ class std::vector<SLArEventChargeHit>++; 
+#pragma link C++ class std::vector<SLArEventPhotonHit>++;
 #pragma link C++ class SLArEventBacktrackerRecord++;
 #pragma link C++ class std::vector<SLArEventBacktrackerRecord>++;
 #pragma link C++ class std::map<Int_t, UShort_t>++;
@@ -26,16 +26,31 @@
 #pragma link C++ class SLArEventHitsCollection<SLArEventPhotonHit>++;
 #pragma link C++ class SLArEventHitsCollection<SLArEventChargeHit>++;
 #pragma link C++ class SLArEventChargePixel++; 
+#pragma link C++ class std::map<int, std::unique_ptr<SLArEventChargePixel>>++; 
 #pragma link C++ class std::map<int, SLArEventChargePixel*>++; 
-#pragma link C++ class SLArEventTile++;
-#pragma link C++ class std::map<int, SLArEventTile*>++;
-#pragma link C++ class SLArEventMegatile++;
-#pragma link C++ class SLArEventAnode++;
-#pragma link C++ class std::map<int, SLArEventAnode*>++;
+#pragma link C++ class SLArEventTile<std::unique_ptr<SLArEventChargePixel>>++;
+#pragma link C++ class SLArEventTile<SLArEventChargePixel*>++;
+#pragma link C++ typedef SLArEventTilePtr++;
+#pragma link C++ typedef SLArEventTileUniquePtr++;
+#pragma link C++ class std::map<int, std::unique_ptr<SLArEventTileUniquePtr>>++;
+#pragma link C++ class std::map<int, SLArEventTilePtr*>++;
+#pragma link C++ class SLArEventMegatile<std::unique_ptr<SLArEventTileUniquePtr>>++;
+#pragma link C++ class SLArEventMegatile<SLArEventTilePtr*>++;
+#pragma link C++ typedef SLArEventMegatilePtr++;
+#pragma link C++ typedef SLArEventMegatileUniquePtr++;
+#pragma link C++ class std::map<int, std::unique_ptr<SLArEventMegatileUniquePtr>>++;
+#pragma link C++ class std::map<int, SLArEventMegatilePtr*>++;
+#pragma link C++ class SLArEventAnode<std::unique_ptr<SLArEventMegatileUniquePtr>, std::unique_ptr<SLArEventTileUniquePtr>, std::unique_ptr<SLArEventChargePixel>>++;
+#pragma link C++ class SLArEventAnode<SLArEventMegatilePtr*, SLArEventTilePtr*, SLArEventChargePixel*>++;
+#pragma link C++ typedef SLArEventAnodePtr++;
+#pragma link C++ typedef SLArEventAnodeUniquePtr++;
 #pragma link C++ class SLArEventSuperCell++;
+#pragma link C++ class std::map<int, std::unique_ptr<SLArEventSuperCell>>++;
 #pragma link C++ class std::map<int, SLArEventSuperCell*>++;
-#pragma link C++ class SLArEventSuperCellArray++;
-#pragma link C++ class std::map<int, SLArEventSuperCellArray*>++;
+#pragma link C++ class SLArEventSuperCellArray<std::unique_ptr<SLArEventSuperCell>>++;
+#pragma link C++ class SLArEventSuperCellArray<SLArEventSuperCell*>++;
+#pragma link C++ typedef SLArEventSuperCellArrayPtr++;
+#pragma link C++ typedef SLArEventSuperCellArrayUniquePtr++;
 
 #endif
 

--- a/G4SOLAr/include/event/SLArEventSuperCell.hh
+++ b/G4SOLAr/include/event/SLArEventSuperCell.hh
@@ -27,7 +27,7 @@ class SLArEventSuperCell : public SLArEventHitsCollection<SLArEventPhotonHit> {
 
     bool IsActive() {return fIsActive;}
 
-    void PrintHits(); 
+    void PrintHits() const ; 
 
   protected:
 

--- a/G4SOLAr/include/event/SLArEventSuperCellArray.hh
+++ b/G4SOLAr/include/event/SLArEventSuperCellArray.hh
@@ -11,7 +11,6 @@
 #include "event/SLArEventSuperCell.hh"
 #include "config/SLArCfgSuperCellArray.hh"
 
-template<class S>
 class SLArEventSuperCellArray : public TNamed {
   public: 
     SLArEventSuperCellArray(); 
@@ -20,15 +19,15 @@ class SLArEventSuperCellArray : public TNamed {
     ~SLArEventSuperCellArray();
 
     int ConfigSystem(SLArCfgSuperCellArray* cfg); 
-    inline std::map<int, S>& GetSuperCellMap() {return fSuperCellMap;}
-    inline const std::map<int, S>& GetConstSuperCellMap() const {return fSuperCellMap;}
+    inline std::map<int, SLArEventSuperCell*>& GetSuperCellMap() {return fSuperCellMap;}
+    inline const std::map<int, SLArEventSuperCell*>& GetConstSuperCellMap() const {return fSuperCellMap;}
     inline int GetNhits() const {return fNhits;}
     inline bool IsActive() const {return fIsActive;}
 
     inline void SetLightBacktrackerRecordSize(const UShort_t size) {fLightBacktrackerRecordSize = size;}
     inline UShort_t GetLightBacktrackerRecordSize() const {return fLightBacktrackerRecordSize;}
-    S& GetOrCreateEventSuperCell(const int scIdx); 
-    S& RegisterHit(const SLArEventPhotonHit& hit); 
+    SLArEventSuperCell* GetOrCreateEventSuperCell(const int scIdx); 
+    SLArEventSuperCell* RegisterHit(const SLArEventPhotonHit& hit); 
     int ResetHits(); 
     int SoftResetHits();
 
@@ -39,14 +38,11 @@ class SLArEventSuperCellArray : public TNamed {
     int fNhits; 
     bool fIsActive; 
     UShort_t fLightBacktrackerRecordSize;
-    std::map<int, S> fSuperCellMap;
+    std::map<int, SLArEventSuperCell*> fSuperCellMap;
 
   public:
     ClassDef(SLArEventSuperCellArray, 2); 
 }; 
-
-typedef SLArEventSuperCellArray<SLArEventSuperCell*> SLArEventSuperCellArrayPtr;
-typedef SLArEventSuperCellArray<std::unique_ptr<SLArEventSuperCell>> SLArEventSuperCellArrayUniquePtr;
 
 #endif /* end of include guard SLAREVENTSUPERCELLARRAY */
 

--- a/G4SOLAr/include/event/SLArEventSuperCellArray.hh
+++ b/G4SOLAr/include/event/SLArEventSuperCellArray.hh
@@ -30,6 +30,7 @@ class SLArEventSuperCellArray : public TNamed {
     S& GetOrCreateEventSuperCell(const int scIdx); 
     S& RegisterHit(const SLArEventPhotonHit& hit); 
     int ResetHits(); 
+    int SoftResetHits();
 
     void SetActive(bool is_active); 
     //bool SortHits(); 

--- a/G4SOLAr/include/event/SLArEventSuperCellArray.hh
+++ b/G4SOLAr/include/event/SLArEventSuperCellArray.hh
@@ -11,6 +11,7 @@
 #include "event/SLArEventSuperCell.hh"
 #include "config/SLArCfgSuperCellArray.hh"
 
+template<class S>
 class SLArEventSuperCellArray : public TNamed {
   public: 
     SLArEventSuperCellArray(); 
@@ -19,15 +20,15 @@ class SLArEventSuperCellArray : public TNamed {
     ~SLArEventSuperCellArray();
 
     int ConfigSystem(SLArCfgSuperCellArray* cfg); 
-    inline std::map<int, SLArEventSuperCell*>& GetSuperCellMap() {return fSuperCellMap;}
-    inline const std::map<int, SLArEventSuperCell*>& GetConstSuperCellMap() {return fSuperCellMap;}
+    inline std::map<int, S>& GetSuperCellMap() {return fSuperCellMap;}
+    inline const std::map<int, S>& GetConstSuperCellMap() const {return fSuperCellMap;}
     inline int GetNhits() const {return fNhits;}
     inline bool IsActive() const {return fIsActive;}
 
     inline void SetLightBacktrackerRecordSize(const UShort_t size) {fLightBacktrackerRecordSize = size;}
     inline UShort_t GetLightBacktrackerRecordSize() const {return fLightBacktrackerRecordSize;}
-    SLArEventSuperCell* CreateEventSuperCell(const int scIdx); 
-    SLArEventSuperCell* RegisterHit(SLArEventPhotonHit* hit); 
+    S& GetOrCreateEventSuperCell(const int scIdx); 
+    S& RegisterHit(const SLArEventPhotonHit& hit); 
     int ResetHits(); 
 
     void SetActive(bool is_active); 
@@ -37,12 +38,14 @@ class SLArEventSuperCellArray : public TNamed {
     int fNhits; 
     bool fIsActive; 
     UShort_t fLightBacktrackerRecordSize;
-    std::map<int, SLArEventSuperCell*> fSuperCellMap;
+    std::map<int, S> fSuperCellMap;
 
   public:
-    ClassDef(SLArEventSuperCellArray, 1); 
+    ClassDef(SLArEventSuperCellArray, 2); 
 }; 
 
+typedef SLArEventSuperCellArray<SLArEventSuperCell*> SLArEventSuperCellArrayPtr;
+typedef SLArEventSuperCellArray<std::unique_ptr<SLArEventSuperCell>> SLArEventSuperCellArrayUniquePtr;
 
 #endif /* end of include guard SLAREVENTSUPERCELLARRAY */
 

--- a/G4SOLAr/include/event/SLArEventSuperCellArray.hh
+++ b/G4SOLAr/include/event/SLArEventSuperCellArray.hh
@@ -19,15 +19,15 @@ class SLArEventSuperCellArray : public TNamed {
     ~SLArEventSuperCellArray();
 
     int ConfigSystem(SLArCfgSuperCellArray* cfg); 
-    inline std::map<int, SLArEventSuperCell*>& GetSuperCellMap() {return fSuperCellMap;}
-    inline const std::map<int, SLArEventSuperCell*>& GetConstSuperCellMap() const {return fSuperCellMap;}
+    inline std::map<int, SLArEventSuperCell>& GetSuperCellMap() {return fSuperCellMap;}
+    inline const std::map<int, SLArEventSuperCell>& GetConstSuperCellMap() const {return fSuperCellMap;}
     inline int GetNhits() const {return fNhits;}
     inline bool IsActive() const {return fIsActive;}
 
     inline void SetLightBacktrackerRecordSize(const UShort_t size) {fLightBacktrackerRecordSize = size;}
     inline UShort_t GetLightBacktrackerRecordSize() const {return fLightBacktrackerRecordSize;}
-    SLArEventSuperCell* GetOrCreateEventSuperCell(const int scIdx); 
-    SLArEventSuperCell* RegisterHit(const SLArEventPhotonHit& hit); 
+    SLArEventSuperCell& GetOrCreateEventSuperCell(const int scIdx); 
+    SLArEventSuperCell& RegisterHit(const SLArEventPhotonHit& hit); 
     int ResetHits(); 
     int SoftResetHits();
 
@@ -38,7 +38,7 @@ class SLArEventSuperCellArray : public TNamed {
     int fNhits; 
     bool fIsActive; 
     UShort_t fLightBacktrackerRecordSize;
-    std::map<int, SLArEventSuperCell*> fSuperCellMap;
+    std::map<int, SLArEventSuperCell> fSuperCellMap;
 
   public:
     ClassDef(SLArEventSuperCellArray, 2); 

--- a/G4SOLAr/include/event/SLArEventTile.hh
+++ b/G4SOLAr/include/event/SLArEventTile.hh
@@ -11,10 +11,12 @@
 #include <iostream>
 #include <vector>
 #include <map>
+#include <memory>
 #include "event/SLArEventHitsCollection.hh"
 #include "event/SLArEventChargePixel.hh"
 #include "event/SLArEventPhotonHit.hh"
 
+template<class P>
 class SLArEventTile :  public SLArEventHitsCollection<SLArEventPhotonHit> 
 {
   public: 
@@ -25,14 +27,14 @@ class SLArEventTile :  public SLArEventHitsCollection<SLArEventPhotonHit>
 
     double GetTime() const;
     double GetTime(EPhProcess proc) const;
-    inline std::map<int, SLArEventChargePixel*>& GetPixelEvents() {return fPixelHits;}
-    inline const std::map<int, SLArEventChargePixel*>& GetConstPixelEvents() const {return fPixelHits;}
+    inline std::map<int, P>& GetPixelEvents() {return fPixelHits;}
+    inline const std::map<int, P>& GetConstPixelEvents() const {return fPixelHits;}
     inline double GetNPixelHits() const {return fPixelHits.size();}
     double GetPixelHits() const; 
     inline void SetChargeBacktrackerRecordSize(const UShort_t size) {fChargeBacktrackerRecordSize = size;}
     inline UShort_t GetChargeBacktrackerRecordSize() const {return fChargeBacktrackerRecordSize;}
-    void PrintHits(); 
-    SLArEventChargePixel* RegisterChargeHit(const int, const SLArEventChargeHit* ); 
+    void PrintHits() const; 
+    P& RegisterChargeHit(const int&, const SLArEventChargeHit& ); 
     int ResetHits(); 
 
     //bool SortHits(); 
@@ -40,11 +42,14 @@ class SLArEventTile :  public SLArEventHitsCollection<SLArEventPhotonHit>
 
   protected:
     UShort_t fChargeBacktrackerRecordSize;
-    std::map<int, SLArEventChargePixel*> fPixelHits; 
+    std::map<int, P> fPixelHits; 
 
   public:
      ClassDef(SLArEventTile, 2)
 };
+
+typedef SLArEventTile<SLArEventChargePixel*> SLArEventTilePtr;
+typedef SLArEventTile<std::unique_ptr<SLArEventChargePixel>> SLArEventTileUniquePtr;
 
 #endif /* end of include guard SLAREVENTTILE_HH */
 

--- a/G4SOLAr/include/event/SLArEventTile.hh
+++ b/G4SOLAr/include/event/SLArEventTile.hh
@@ -26,14 +26,14 @@ class SLArEventTile :  public SLArEventHitsCollection<SLArEventPhotonHit>
 
     double GetTime() const;
     double GetTime(EPhProcess proc) const;
-    inline std::map<int, SLArEventChargePixel*>& GetPixelEvents() {return fPixelHits;}
-    inline const std::map<int, SLArEventChargePixel*>& GetConstPixelEvents() const {return fPixelHits;}
+    inline std::map<int, SLArEventChargePixel>& GetPixelEvents() {return fPixelHits;}
+    inline const std::map<int, SLArEventChargePixel>& GetConstPixelEvents() const {return fPixelHits;}
     inline double GetNPixelHits() const {return fPixelHits.size();}
     double GetPixelHits() const; 
     inline void SetChargeBacktrackerRecordSize(const UShort_t size) {fChargeBacktrackerRecordSize = size;}
     inline UShort_t GetChargeBacktrackerRecordSize() const {return fChargeBacktrackerRecordSize;}
     void PrintHits() const; 
-    SLArEventChargePixel* RegisterChargeHit(const int&, const SLArEventChargeHit& ); 
+    SLArEventChargePixel& RegisterChargeHit(const int&, const SLArEventChargeHit& ); 
     int ResetHits(); 
     int SoftResetHits();
 
@@ -42,7 +42,7 @@ class SLArEventTile :  public SLArEventHitsCollection<SLArEventPhotonHit>
 
   protected:
     UShort_t fChargeBacktrackerRecordSize;
-    std::map<int, SLArEventChargePixel*> fPixelHits; 
+    std::map<int, SLArEventChargePixel> fPixelHits; 
 
   public:
      ClassDef(SLArEventTile, 2)

--- a/G4SOLAr/include/event/SLArEventTile.hh
+++ b/G4SOLAr/include/event/SLArEventTile.hh
@@ -24,6 +24,8 @@ class SLArEventTile :  public SLArEventHitsCollection<SLArEventPhotonHit>
     SLArEventTile(const int idx); 
     SLArEventTile(const SLArEventTile& ev); 
     ~SLArEventTile(); 
+    template<class T>
+    void SoftCopy(SLArEventTile<T>& record) const; 
 
     double GetTime() const;
     double GetTime(EPhProcess proc) const;
@@ -36,6 +38,7 @@ class SLArEventTile :  public SLArEventHitsCollection<SLArEventPhotonHit>
     void PrintHits() const; 
     P& RegisterChargeHit(const int&, const SLArEventChargeHit& ); 
     int ResetHits(); 
+    int SoftResetHits();
 
     //bool SortHits(); 
     //bool SortPixelHits();

--- a/G4SOLAr/include/event/SLArEventTile.hh
+++ b/G4SOLAr/include/event/SLArEventTile.hh
@@ -16,7 +16,6 @@
 #include "event/SLArEventChargePixel.hh"
 #include "event/SLArEventPhotonHit.hh"
 
-template<class P>
 class SLArEventTile :  public SLArEventHitsCollection<SLArEventPhotonHit> 
 {
   public: 
@@ -24,19 +23,17 @@ class SLArEventTile :  public SLArEventHitsCollection<SLArEventPhotonHit>
     SLArEventTile(const int idx); 
     SLArEventTile(const SLArEventTile& ev); 
     ~SLArEventTile(); 
-    template<class T>
-    void SoftCopy(SLArEventTile<T>& record) const; 
 
     double GetTime() const;
     double GetTime(EPhProcess proc) const;
-    inline std::map<int, P>& GetPixelEvents() {return fPixelHits;}
-    inline const std::map<int, P>& GetConstPixelEvents() const {return fPixelHits;}
+    inline std::map<int, SLArEventChargePixel*>& GetPixelEvents() {return fPixelHits;}
+    inline const std::map<int, SLArEventChargePixel*>& GetConstPixelEvents() const {return fPixelHits;}
     inline double GetNPixelHits() const {return fPixelHits.size();}
     double GetPixelHits() const; 
     inline void SetChargeBacktrackerRecordSize(const UShort_t size) {fChargeBacktrackerRecordSize = size;}
     inline UShort_t GetChargeBacktrackerRecordSize() const {return fChargeBacktrackerRecordSize;}
     void PrintHits() const; 
-    P& RegisterChargeHit(const int&, const SLArEventChargeHit& ); 
+    SLArEventChargePixel* RegisterChargeHit(const int&, const SLArEventChargeHit& ); 
     int ResetHits(); 
     int SoftResetHits();
 
@@ -45,14 +42,11 @@ class SLArEventTile :  public SLArEventHitsCollection<SLArEventPhotonHit>
 
   protected:
     UShort_t fChargeBacktrackerRecordSize;
-    std::map<int, P> fPixelHits; 
+    std::map<int, SLArEventChargePixel*> fPixelHits; 
 
   public:
      ClassDef(SLArEventTile, 2)
 };
-
-typedef SLArEventTile<SLArEventChargePixel*> SLArEventTilePtr;
-typedef SLArEventTile<std::unique_ptr<SLArEventChargePixel>> SLArEventTileUniquePtr;
 
 #endif /* end of include guard SLAREVENTTILE_HH */
 

--- a/G4SOLAr/include/event/SLArEventTrajectory.hh
+++ b/G4SOLAr/include/event/SLArEventTrajectory.hh
@@ -25,6 +25,7 @@ struct trj_point {
   bool  fLAr;
 
   trj_point() : fX(0.), fY(0.), fZ(0.), fKEnergy(0.), fEdep(0.), fNph(0), fNel(0), fCopy(0), fLAr(false) {}
+
   trj_point(double x, double y, double z, double energy, double edep, int n_ph = 0, int n_el = 0, int copy = 0, bool in_lar = false) {
     fX = x; 
     fY = y; 
@@ -36,6 +37,7 @@ struct trj_point {
     fCopy = copy;
     fLAr = in_lar;
   }
+
 };
 
 
@@ -44,7 +46,7 @@ class SLArEventTrajectory : public TObject
 {
   public:
     SLArEventTrajectory();
-    SLArEventTrajectory(SLArEventTrajectory* trj);
+    SLArEventTrajectory(const SLArEventTrajectory& trj);
     ~SLArEventTrajectory();
 
     TString GetParticleName() const {return fParticleName;}
@@ -62,22 +64,23 @@ class SLArEventTrajectory : public TObject
     float GetTotalNph () const {return fTotalNph;} 
     float GetTotalNel () const {return fTotalNel;} 
 
-    inline void SetParticleName(const TString name) {fParticleName = name;}
-    inline void SetCreatorProcess(const TString proc) {fCreatorProcess = proc;}
-    inline void SetEndProcess(const TString proc) {fEndProcess = proc;}
-    inline void SetPDGID(const int pdgID) {fPDGID = pdgID;}
-    inline void SetTrackID(const int trkID) {fTrackID = trkID;}
-    inline void SetParentID(const int prtID) {fParentID = prtID;}
-    inline void SetInitKineticEne(const float k) {fInitKineticEnergy=k;}
-    inline void SetTrackLength(const float l) {fTrackLength = l;}
-    inline void SetInitMomentum(const TVector3 p) {fInitMomentum = p;}
-    inline void SetTime(const float t) {fTime = t;}
-    inline void SetWeight(const float w) {fWeight = w;}
-    inline void IncrementEdep(const double edep) {fTotalEdep += edep;}
-    inline void IncrementNion(const int nion) {fTotalNel += nion;}
-    inline void IncrementNph(const int nph) {fTotalNph += nph;}
+    inline void SetParticleName(const TString& name) {fParticleName = name;}
+    inline void SetCreatorProcess(const TString& proc) {fCreatorProcess = proc;}
+    inline void SetEndProcess(const TString& proc) {fEndProcess = proc;}
+    inline void SetPDGID(const int& pdgID) {fPDGID = pdgID;}
+    inline void SetTrackID(const int& trkID) {fTrackID = trkID;}
+    inline void SetParentID(const int& prtID) {fParentID = prtID;}
+    inline void SetInitKineticEne(const float& k) {fInitKineticEnergy=k;}
+    inline void SetTrackLength(const float& l) {fTrackLength = l;}
+    inline void SetInitMomentum(const TVector3& p) {fInitMomentum = p;}
+    inline void SetTime(const float& t) {fTime = t;}
+    inline void SetWeight(const float& w) {fWeight = w;}
+    inline void IncrementEdep(const double& edep) {fTotalEdep += edep;}
+    inline void IncrementNion(const int& nion) {fTotalNel += nion;}
+    inline void IncrementNph(const int& nph) {fTotalNph += nph;}
 
-    std::vector<trj_point>& GetPoints()      {return fTrjPoints   ;}
+    std::vector<trj_point>& GetPoints()      {return fTrjPoints;}
+    const std::vector<trj_point>& GetConstPoints()  const {return fTrjPoints;}
     void    RegisterPoint(double x, double y, double z, double ene, double edep, int n_ph, int n_el, int copy);
     void    RegisterPoint(const trj_point& point); 
 

--- a/G4SOLAr/include/event/SLArEventTrajectory.hh
+++ b/G4SOLAr/include/event/SLArEventTrajectory.hh
@@ -63,7 +63,9 @@ class SLArEventTrajectory : public TObject
     float GetTotalEdep() const {return fTotalEdep;} 
     float GetTotalNph () const {return fTotalNph;} 
     float GetTotalNel () const {return fTotalNel;} 
+    Bool_t DoStoreTrajectoryPts() const {return fStoreTrajectoryPts;}
 
+    inline void SetStoreTrajectoryPts(const bool store_pts) {fStoreTrajectoryPts = store_pts;}
     inline void SetParticleName(const TString& name) {fParticleName = name;}
     inline void SetCreatorProcess(const TString& proc) {fCreatorProcess = proc;}
     inline void SetEndProcess(const TString& proc) {fEndProcess = proc;}
@@ -86,6 +88,7 @@ class SLArEventTrajectory : public TObject
 
 
   private:
+    Bool_t                 fStoreTrajectoryPts;
     TString                fParticleName     ; 
     TString                fCreatorProcess   ; 
     TString                fEndProcess       ;

--- a/G4SOLAr/include/event/SLArMCEvent.hh
+++ b/G4SOLAr/include/event/SLArMCEvent.hh
@@ -30,7 +30,6 @@
  * detected hits for each detector sub-system (Tile SiPMs, Tile pixels, SuperCell)
  *              
  */
-template<class P, class A, class X>
 class SLArMCEvent : public TObject
 {
   public: 
@@ -56,36 +55,32 @@ class SLArMCEvent : public TObject
     int ConfigAnode (std::map<int, SLArCfgAnode*> anodeCfg);
     int ConfigSuperCellSystem (SLArCfgSystemSuperCell* supercellSysCfg); 
 
-    inline std::map<int, A>& GetEventAnode() {return fEvAnode;}
-    inline A& GetEventAnodeByTPCID(const int& id) {return fEvAnode.find(id)->second;}
-    A& GetEventAnodeByID(const int& id); 
-    inline std::map<int, X>& GetEventSuperCellArray() {return fEvSuperCellArray;}
-    inline X& GetEventSuperCellArray(const int& id) {return fEvSuperCellArray.find(id)->second;}
+    inline std::map<int, SLArEventAnode*>& GetEventAnode() {return fEvAnode;}
+    inline SLArEventAnode* GetEventAnodeByTPCID(const int& id) {return fEvAnode.find(id)->second;}
+    SLArEventAnode* GetEventAnodeByID(const int& id); 
+    inline std::map<int, SLArEventSuperCellArray*>& GetEventSuperCellArray() {return fEvSuperCellArray;}
+    inline SLArEventSuperCellArray* GetEventSuperCellArray(const int& id) {return fEvSuperCellArray.find(id)->second;}
 
-    inline std::vector<P>& GetPrimaries() {return fSLArPrimary ;}
-    inline P& GetPrimary(int ip) {return fSLArPrimary.at(ip);}
+    inline std::vector<SLArMCPrimaryInfo*>& GetPrimaries() {return fSLArPrimary ;}
+    inline SLArMCPrimaryInfo* GetPrimary(int ip) {return fSLArPrimary.at(ip);}
     bool  CheckIfPrimary(int trkId) const;
 
-    size_t RegisterPrimary(P p);
+    size_t RegisterPrimary(SLArMCPrimaryInfo* p);
     void  Reset();
 
   private:
     int fEvNumber; //!< Event number
     std::array<double, 3>  fDirection; //!< Event Direction 
     //! Event's primary particles (and associated secondaries)
-    std::vector<P> fSLArPrimary;  
+    std::vector<SLArMCPrimaryInfo*> fSLArPrimary;  
     //! Event data structure of the readout tile system
-    std::map<int, A> fEvAnode;
+    std::map<int, SLArEventAnode*> fEvAnode;
     //! Event data structure of the super-cell system
-    std::map<int, X> fEvSuperCellArray; 
+    std::map<int, SLArEventSuperCellArray*> fEvSuperCellArray; 
 
   public:
     ClassDef(SLArMCEvent, 2);
 };
-
-typedef SLArMCEvent<SLArMCPrimaryInfoPtr*, SLArEventAnodePtr*, SLArEventSuperCellArrayPtr*> SLArMCEventPtr;
-typedef SLArMCEvent<std::unique_ptr<SLArMCPrimaryInfoUniquePtr>, std::unique_ptr<SLArEventAnodeUniquePtr>, std::unique_ptr<SLArEventSuperCellArrayUniquePtr>> SLArMCEventUniquePtr;
-
 
 #endif /* end of include guard SLArEVENT_HH */
 

--- a/G4SOLAr/include/event/SLArMCEvent.hh
+++ b/G4SOLAr/include/event/SLArMCEvent.hh
@@ -12,6 +12,7 @@
 #include <fstream>
 #include <map>
 #include <vector>
+#include <memory>
 
 #include "event/SLArMCPrimaryInfo.hh"
 #include "event/SLArEventAnode.hh"
@@ -29,12 +30,15 @@
  * detected hits for each detector sub-system (Tile SiPMs, Tile pixels, SuperCell)
  *              
  */
+template<class P, class A, class X>
 class SLArMCEvent : public TObject
 {
   public: 
 
     //! Empty constructor
     SLArMCEvent();
+    //! Copy constructor
+    SLArMCEvent(const SLArMCEvent&);
     //! Destructuor
     ~SLArMCEvent();
 
@@ -52,34 +56,35 @@ class SLArMCEvent : public TObject
     int ConfigAnode (std::map<int, SLArCfgAnode*> anodeCfg);
     int ConfigSuperCellSystem (SLArCfgSystemSuperCell* supercellSysCfg); 
 
-    inline std::map<int, SLArEventAnode*>& GetEventAnode() {return fEvAnode;}
-    inline SLArEventAnode* GetEventAnodeByTPCID(int id) {return fEvAnode.find(id)->second;}
-    SLArEventAnode* GetEventAnodeByID(int id); 
-    inline std::map<int, SLArEventSuperCellArray*>& GetEventSuperCellArray() {return fEvSuperCellArray;}
-    inline SLArEventSuperCellArray* GetEventSuperCellArray(int id) {return fEvSuperCellArray.find(id)->second;}
+    inline std::map<int, A>& GetEventAnode() {return fEvAnode;}
+    inline A& GetEventAnodeByTPCID(const int& id) {return fEvAnode.find(id)->second;}
+    A& GetEventAnodeByID(const int& id); 
+    inline std::map<int, X>& GetEventSuperCellArray() {return fEvSuperCellArray;}
+    inline X& GetEventSuperCellArray(const int& id) {return fEvSuperCellArray.find(id)->second;}
 
-    inline std::vector<SLArMCPrimaryInfo*>& GetPrimaries() {return fSLArPrimary ;}
-    inline SLArMCPrimaryInfo* GetPrimary(int ip) {return fSLArPrimary.at(ip);}
-    bool  CheckIfPrimary(int trkId);
+    inline std::vector<P>& GetPrimaries() {return fSLArPrimary ;}
+    inline P& GetPrimary(int ip) {return fSLArPrimary.at(ip);}
+    bool  CheckIfPrimary(int trkId) const;
 
-    inline size_t RegisterPrimary(SLArMCPrimaryInfo* p) 
-      {fSLArPrimary.push_back(p); return fSLArPrimary.size();}
-
+    size_t RegisterPrimary(P p);
     void  Reset();
 
   private:
     int fEvNumber; //!< Event number
     std::array<double, 3>  fDirection; //!< Event Direction 
     //! Event's primary particles (and associated secondaries)
-    std::vector<SLArMCPrimaryInfo*> fSLArPrimary;  
+    std::vector<P> fSLArPrimary;  
     //! Event data structure of the readout tile system
-    std::map<int, SLArEventAnode*> fEvAnode;
+    std::map<int, A> fEvAnode;
     //! Event data structure of the super-cell system
-    std::map<int, SLArEventSuperCellArray*> fEvSuperCellArray; 
+    std::map<int, X> fEvSuperCellArray; 
 
   public:
     ClassDef(SLArMCEvent, 2);
 };
+
+typedef SLArMCEvent<SLArMCPrimaryInfoPtr*, SLArEventAnodePtr*, SLArEventSuperCellArrayPtr*> SLArMCEventPtr;
+typedef SLArMCEvent<std::unique_ptr<SLArMCPrimaryInfoUniquePtr>, std::unique_ptr<SLArEventAnodeUniquePtr>, std::unique_ptr<SLArEventSuperCellArrayUniquePtr>> SLArMCEventUniquePtr;
 
 
 #endif /* end of include guard SLArEVENT_HH */

--- a/G4SOLAr/include/event/SLArMCEvent.hh
+++ b/G4SOLAr/include/event/SLArMCEvent.hh
@@ -55,28 +55,28 @@ class SLArMCEvent : public TObject
     int ConfigAnode (std::map<int, SLArCfgAnode*> anodeCfg);
     int ConfigSuperCellSystem (SLArCfgSystemSuperCell* supercellSysCfg); 
 
-    inline std::map<int, SLArEventAnode*>& GetEventAnode() {return fEvAnode;}
-    inline SLArEventAnode* GetEventAnodeByTPCID(const int& id) {return fEvAnode.find(id)->second;}
-    SLArEventAnode* GetEventAnodeByID(const int& id); 
-    inline std::map<int, SLArEventSuperCellArray*>& GetEventSuperCellArray() {return fEvSuperCellArray;}
-    inline SLArEventSuperCellArray* GetEventSuperCellArray(const int& id) {return fEvSuperCellArray.find(id)->second;}
+    inline std::map<int, SLArEventAnode>& GetEventAnode() {return fEvAnode;}
+    inline SLArEventAnode& GetEventAnodeByTPCID(const int& id) {return fEvAnode.find(id)->second;}
+    SLArEventAnode& GetEventAnodeByID(const int& id); 
+    inline std::map<int, SLArEventSuperCellArray>& GetEventSuperCellArray() {return fEvSuperCellArray;}
+    inline SLArEventSuperCellArray& GetEventSuperCellArray(const int& id) {return fEvSuperCellArray.find(id)->second;}
 
-    inline std::vector<SLArMCPrimaryInfo*>& GetPrimaries() {return fSLArPrimary ;}
-    inline SLArMCPrimaryInfo* GetPrimary(int ip) {return fSLArPrimary.at(ip);}
+    inline std::vector<SLArMCPrimaryInfo>& GetPrimaries() {return fSLArPrimary ;}
+    inline SLArMCPrimaryInfo& GetPrimary(int ip) {return fSLArPrimary.at(ip);}
     bool  CheckIfPrimary(int trkId) const;
 
-    size_t RegisterPrimary(SLArMCPrimaryInfo* p);
+    size_t RegisterPrimary(SLArMCPrimaryInfo& p);
     void  Reset();
 
   private:
     int fEvNumber; //!< Event number
     std::array<double, 3>  fDirection; //!< Event Direction 
     //! Event's primary particles (and associated secondaries)
-    std::vector<SLArMCPrimaryInfo*> fSLArPrimary;  
+    std::vector<SLArMCPrimaryInfo> fSLArPrimary;  
     //! Event data structure of the readout tile system
-    std::map<int, SLArEventAnode*> fEvAnode;
+    std::map<int, SLArEventAnode> fEvAnode;
     //! Event data structure of the super-cell system
-    std::map<int, SLArEventSuperCellArray*> fEvSuperCellArray; 
+    std::map<int, SLArEventSuperCellArray> fEvSuperCellArray; 
 
   public:
     ClassDef(SLArMCEvent, 2);

--- a/G4SOLAr/include/event/SLArMCEventLinkDef.h
+++ b/G4SOLAr/include/event/SLArMCEventLinkDef.h
@@ -4,8 +4,8 @@
 #pragma link off all functions;
 
 #pragma link C++ class std::vector<SLArMCPrimaryInfo>+;
-#pragma link C++ class std::map<int, SLArEventSuperCellArray*>++;
-#pragma link C++ class std::map<int, SLArEventAnode*>++;
+#pragma link C++ class std::map<int, SLArEventSuperCellArray>++;
+#pragma link C++ class std::map<int, SLArEventAnode>++;
 #pragma link C++ class SLArMCEvent+;
 #endif
 

--- a/G4SOLAr/include/event/SLArMCEventLinkDef.h
+++ b/G4SOLAr/include/event/SLArMCEventLinkDef.h
@@ -3,15 +3,9 @@
 #pragma link off all classes;
 #pragma link off all functions;
 
-#pragma link C++ class std::vector<std::unique_ptr<SLArMCPrimaryInfoUniquePtr>>+;
-#pragma link C++ class std::vector<SLArMCPrimaryInfoPtr*>+;
-#pragma link C++ class std::map<int, std::unique_ptr<SLArEventSuperCellArrayUniquePtr>>++;
-#pragma link C++ class std::map<int, SLArEventSuperCellArrayPtr*>++;
-#pragma link C++ class std::map<int, std::unique_ptr<SLArEventAnodeUniquePtr>>++;
-#pragma link C++ class std::map<int, SLArEventAnodePtr*>++;
-#pragma link C++ class SLArMCEvent<SLArMCPrimaryInfoPtr*, SLArEventAnodePtr*, SLArEventSuperCellArrayPtr*>+;
-#pragma link C++ class SLArMCEvent<std::unique_ptr<SLArMCPrimaryInfoUniquePtr>, std::unique_ptr<SLArEventAnodeUniquePtr>, std::unique_ptr<SLArEventSuperCellArrayUniquePtr>>+;
-#pragma link C++ typedef SLArMCEventPtr+;
-#pragma link C++ typedef SLArMCEventUniquePtr+;
+#pragma link C++ class std::vector<SLArMCPrimaryInfo>+;
+#pragma link C++ class std::map<int, SLArEventSuperCellArray*>++;
+#pragma link C++ class std::map<int, SLArEventAnode*>++;
+#pragma link C++ class SLArMCEvent+;
 #endif
 

--- a/G4SOLAr/include/event/SLArMCEventLinkDef.h
+++ b/G4SOLAr/include/event/SLArMCEventLinkDef.h
@@ -3,7 +3,15 @@
 #pragma link off all classes;
 #pragma link off all functions;
 
-#pragma link C++ class std::vector<SLArMCPrimaryInfo*>+;
-#pragma link C++ class SLArMCEvent+;
+#pragma link C++ class std::vector<std::unique_ptr<SLArMCPrimaryInfoUniquePtr>>+;
+#pragma link C++ class std::vector<SLArMCPrimaryInfoPtr*>+;
+#pragma link C++ class std::map<int, std::unique_ptr<SLArEventSuperCellArrayUniquePtr>>++;
+#pragma link C++ class std::map<int, SLArEventSuperCellArrayPtr*>++;
+#pragma link C++ class std::map<int, std::unique_ptr<SLArEventAnodeUniquePtr>>++;
+#pragma link C++ class std::map<int, SLArEventAnodePtr*>++;
+#pragma link C++ class SLArMCEvent<SLArMCPrimaryInfoPtr*, SLArEventAnodePtr*, SLArEventSuperCellArrayPtr*>+;
+#pragma link C++ class SLArMCEvent<std::unique_ptr<SLArMCPrimaryInfoUniquePtr>, std::unique_ptr<SLArEventAnodeUniquePtr>, std::unique_ptr<SLArEventSuperCellArrayUniquePtr>>+;
+#pragma link C++ typedef SLArMCEventPtr+;
+#pragma link C++ typedef SLArMCEventUniquePtr+;
 #endif
 

--- a/G4SOLAr/include/event/SLArMCPrimaryInfo.hh
+++ b/G4SOLAr/include/event/SLArMCPrimaryInfo.hh
@@ -23,25 +23,30 @@ class SLArMCPrimaryInfo : public TNamed
     SLArMCPrimaryInfo(const SLArMCPrimaryInfo& p);
     ~SLArMCPrimaryInfo();
 
+    template<class R>
+    void SoftCopy(SLArMCPrimaryInfo<R>& record) const;
+
     void SetPosition(const double&  x, const double&  y, const double&  z, const double& t = 0);
     void SetMomentum(const double& px, const double& py, const double& pz, const double&   ene);
-    void SetID(const int& id) {fID = id;}
-    void SetTrackID(const int& id) {fTrkID = id;}
-    void SetName(const char* name) {fName = name;}
-    void SetTime(const double& time) {fTime = time;}
+    inline void SetID(const int& id) {fID = id;}
+    inline void SetTrackID(const int& id) {fTrkID = id;}
+    inline void SetName(const char* name) {fName = name;}
+    inline void SetTime(const double& time) {fTime = time;}
+    inline void SetTotalEdep(const float& edep) {fTotalEdep = edep;}
+    inline void SetTotalLArEdep(const float& edep) {fTotalLArEdep = edep;}
+    inline void SetTotalScintPhotons(const int& nph) {fTotalScintPhotons = nph;}
+    inline void SetTotalCerenkovPhotons(const int& nph) {fTotalCerenkovPhotons = nph;}
 
-    void SetTotalEdep (float& edep) {fTotalEdep = edep;}
-
-    inline TString GetParticleName() const {return fName     ;}
-    inline std::vector<double> GetMomentum() const {return fMomentum ;}
-    inline std::vector<double> GetVertex() const {return fVertex   ;}
-    inline double GetEnergy() const {return fEnergy   ;}
-    inline int GetCode() const {return fID       ;}
-    inline double GetTime() const {return fTime     ;}
+    inline TString GetParticleName() const {return fName;}
+    inline std::vector<double> GetMomentum() const {return fMomentum;}
+    inline std::vector<double> GetVertex() const {return fVertex;}
+    inline double GetEnergy() const {return fEnergy;}
+    inline int GetCode() const {return fID;}
+    inline double GetTime() const {return fTime;}
     inline double GetTotalEdep() const {return fTotalEdep;}
     inline double GetTotalLArEdep() const {return fTotalLArEdep;}
-    inline int GetID() const {return fID       ;}
-    inline int GetTrackID() const {return fTrkID    ;}
+    inline int GetID() const {return fID;}
+    inline int GetTrackID() const {return fTrkID;}
     inline std::vector<T>& GetTrajectories() {return fTrajectories;}
     inline const std::vector<T>& GetConstTrajectories() const {return fTrajectories;}
     inline int GetTotalScintPhotons() const {return fTotalScintPhotons;}
@@ -54,21 +59,22 @@ class SLArMCPrimaryInfo : public TNamed
     void PrintParticle() const;
 
     void ResetParticle();
+    void SoftResetParticle();
     
     int RegisterTrajectory(T trj);
 
   private:
-    Int_t    fID      ; 
-    Int_t    fTrkID   ;
-    TString  fName    ; 
-    double   fEnergy  ;
-    double   fTime    ;
-    double   fTotalEdep;
-    Int_t    fTotalScintPhotons;
-    Int_t    fTotalCerenkovPhotons;
-    double   fTotalLArEdep; 
-    std::vector<double>   fVertex  ;
-    std::vector<double>   fMomentum;
+    Int_t fID; 
+    Int_t fTrkID;
+    TString fName; 
+    double fEnergy;
+    double fTime;
+    double fTotalEdep;
+    Int_t fTotalScintPhotons;
+    Int_t fTotalCerenkovPhotons;
+    double fTotalLArEdep; 
+    std::vector<double> fVertex;
+    std::vector<double> fMomentum;
     std::vector<T> fTrajectories;
   
   public:

--- a/G4SOLAr/include/event/SLArMCPrimaryInfo.hh
+++ b/G4SOLAr/include/event/SLArMCPrimaryInfo.hh
@@ -9,49 +9,53 @@
 #define SLArMCPRIMARYINFO_HH
 
 #include <iostream>
+#include <vector>
+#include <memory>
 #include "TNamed.h"
 #include "TH3F.h"
 #include "event/SLArEventTrajectory.hh"
 
+template<class T>
 class SLArMCPrimaryInfo : public TNamed 
 {
   public:
     SLArMCPrimaryInfo();
+    SLArMCPrimaryInfo(const SLArMCPrimaryInfo& p);
     ~SLArMCPrimaryInfo();
 
-    void SetPosition(double  x, double  y, double  z, double t = 0);
-    void SetMomentum(double px, double py, double pz, double   ene);
-    void SetID      (const int id) {fID    =   id;}
-    void SetTrackID (const int id) {fTrkID =   id;}
-    void SetName    (const char* name) {fName = name;}
-    void SetTime    (const double time) {fTime = time;}
+    void SetPosition(const double&  x, const double&  y, const double&  z, const double& t = 0);
+    void SetMomentum(const double& px, const double& py, const double& pz, const double&   ene);
+    void SetID(const int& id) {fID = id;}
+    void SetTrackID(const int& id) {fTrkID = id;}
+    void SetName(const char* name) {fName = name;}
+    void SetTime(const double& time) {fTime = time;}
 
-    void SetTotalEdep   (float edep)   {fTotalEdep    = edep;}
+    void SetTotalEdep (float& edep) {fTotalEdep = edep;}
 
-    inline TString   GetParticleName() {return fName     ;}
-    inline std::vector<double>   GetMomentum    () {return fMomentum ;}
-    inline std::vector<double>   GetVertex      () {return fVertex   ;}
-    inline double    GetEnergy      () {return fEnergy   ;}
-    inline int       GetCode        () {return fID       ;}
-    inline double    GetTime        () {return fTime     ;}
-    inline double    GetTotalEdep   () {return fTotalEdep;}
-    inline double    GetTotalLArEdep() {return fTotalLArEdep;}
-    inline int       GetID          () {return fID       ;}
-    inline int       GetTrackID     () {return fTrkID    ;}
-    std::vector<SLArEventTrajectory*>&
-              GetTrajectories() {return fTrajectories;}
-    int       GetTotalScintPhotons() {return fTotalScintPhotons;}
-    int       GetTotalCerenkovPhotons() {return fTotalCerenkovPhotons;}
+    inline TString GetParticleName() const {return fName     ;}
+    inline std::vector<double> GetMomentum() const {return fMomentum ;}
+    inline std::vector<double> GetVertex() const {return fVertex   ;}
+    inline double GetEnergy() const {return fEnergy   ;}
+    inline int GetCode() const {return fID       ;}
+    inline double GetTime() const {return fTime     ;}
+    inline double GetTotalEdep() const {return fTotalEdep;}
+    inline double GetTotalLArEdep() const {return fTotalLArEdep;}
+    inline int GetID() const {return fID       ;}
+    inline int GetTrackID() const {return fTrkID    ;}
+    inline std::vector<T>& GetTrajectories() {return fTrajectories;}
+    inline const std::vector<T>& GetConstTrajectories() const {return fTrajectories;}
+    inline int GetTotalScintPhotons() const {return fTotalScintPhotons;}
+    inline int GetTotalCerenkovPhotons() const {return fTotalCerenkovPhotons;}
 
-    void      IncrementLArEdep(const double edep) {fTotalLArEdep += edep;}
-    void      IncrementScintPhotons() {fTotalScintPhotons++;}
-    void      IncrementCherPhotons() {fTotalCerenkovPhotons++;}
+    inline void IncrementLArEdep(const double edep) {fTotalLArEdep += edep;}
+    inline void IncrementScintPhotons() {fTotalScintPhotons++;}
+    inline void IncrementCherPhotons() {fTotalCerenkovPhotons++;}
 
-    void PrintParticle();
+    void PrintParticle() const;
 
     void ResetParticle();
     
-    int RegisterTrajectory(SLArEventTrajectory* trj);
+    int RegisterTrajectory(T trj);
 
   private:
     Int_t    fID      ; 
@@ -65,13 +69,14 @@ class SLArMCPrimaryInfo : public TNamed
     double   fTotalLArEdep; 
     std::vector<double>   fVertex  ;
     std::vector<double>   fMomentum;
-    std::vector<SLArEventTrajectory*> fTrajectories;
+    std::vector<T> fTrajectories;
   
   public:
-    ClassDef(SLArMCPrimaryInfo, 2);
+    ClassDef(SLArMCPrimaryInfo, 3);
 };
 
-
+typedef SLArMCPrimaryInfo<SLArEventTrajectory*> SLArMCPrimaryInfoPtr;
+typedef SLArMCPrimaryInfo<std::unique_ptr<SLArEventTrajectory>> SLArMCPrimaryInfoUniquePtr;
 
 #endif /* end of include guard SLArMCTRACKINFO_HH */
 

--- a/G4SOLAr/include/event/SLArMCPrimaryInfo.hh
+++ b/G4SOLAr/include/event/SLArMCPrimaryInfo.hh
@@ -15,16 +15,12 @@
 #include "TH3F.h"
 #include "event/SLArEventTrajectory.hh"
 
-template<class T>
 class SLArMCPrimaryInfo : public TNamed 
 {
   public:
     SLArMCPrimaryInfo();
     SLArMCPrimaryInfo(const SLArMCPrimaryInfo& p);
     ~SLArMCPrimaryInfo();
-
-    template<class R>
-    void SoftCopy(SLArMCPrimaryInfo<R>& record) const;
 
     void SetPosition(const double&  x, const double&  y, const double&  z, const double& t = 0);
     void SetMomentum(const double& px, const double& py, const double& pz, const double&   ene);
@@ -47,8 +43,8 @@ class SLArMCPrimaryInfo : public TNamed
     inline double GetTotalLArEdep() const {return fTotalLArEdep;}
     inline int GetID() const {return fID;}
     inline int GetTrackID() const {return fTrkID;}
-    inline std::vector<T>& GetTrajectories() {return fTrajectories;}
-    inline const std::vector<T>& GetConstTrajectories() const {return fTrajectories;}
+    inline std::vector<std::unique_ptr<SLArEventTrajectory>>& GetTrajectories() {return fTrajectories;}
+    inline const std::vector<std::unique_ptr<SLArEventTrajectory>>& GetConstTrajectories() const {return fTrajectories;}
     inline int GetTotalScintPhotons() const {return fTotalScintPhotons;}
     inline int GetTotalCerenkovPhotons() const {return fTotalCerenkovPhotons;}
 
@@ -61,7 +57,7 @@ class SLArMCPrimaryInfo : public TNamed
     void ResetParticle();
     void SoftResetParticle();
     
-    int RegisterTrajectory(T trj);
+    int RegisterTrajectory(std::unique_ptr<SLArEventTrajectory> trj);
 
   private:
     Int_t fID; 
@@ -75,14 +71,11 @@ class SLArMCPrimaryInfo : public TNamed
     double fTotalLArEdep; 
     std::vector<double> fVertex;
     std::vector<double> fMomentum;
-    std::vector<T> fTrajectories;
+    std::vector<std::unique_ptr<SLArEventTrajectory>> fTrajectories;
   
   public:
     ClassDef(SLArMCPrimaryInfo, 3);
 };
-
-typedef SLArMCPrimaryInfo<SLArEventTrajectory*> SLArMCPrimaryInfoPtr;
-typedef SLArMCPrimaryInfo<std::unique_ptr<SLArEventTrajectory>> SLArMCPrimaryInfoUniquePtr;
 
 #endif /* end of include guard SLArMCTRACKINFO_HH */
 

--- a/G4SOLAr/include/event/SLArMCPrimaryInfoLinkDef.h
+++ b/G4SOLAr/include/event/SLArMCPrimaryInfoLinkDef.h
@@ -14,10 +14,6 @@
 #pragma link C++ class std::vector<trj_point>+;
 #pragma link C++ class SLArEventTrajectory+;
 #pragma link C++ class std::vector<std::unique_ptr<SLArEventTrajectory>>+;
-#pragma link C++ class std::vector<SLArEventTrajectory*>+;
-#pragma link C++ class SLArMCPrimaryInfo<SLArEventTrajectory*>+;
-#pragma link C++ class SLArMCPrimaryInfo<std::unique_ptr<SLArEventTrajectory>>+;
-#pragma link C++ typedef SLArMCPrimaryInfoPtr+;
-#pragma link C++ typedef SLArMCPrimaryInfoUniquePtr+;
+#pragma link C++ class SLArMCPrimaryInfo+;
 #endif
 

--- a/G4SOLAr/include/event/SLArMCPrimaryInfoLinkDef.h
+++ b/G4SOLAr/include/event/SLArMCPrimaryInfoLinkDef.h
@@ -13,7 +13,11 @@
 #pragma link C++ struct trj_point+;
 #pragma link C++ class std::vector<trj_point>+;
 #pragma link C++ class SLArEventTrajectory+;
+#pragma link C++ class std::vector<std::unique_ptr<SLArEventTrajectory>>+;
 #pragma link C++ class std::vector<SLArEventTrajectory*>+;
-#pragma link C++ class SLArMCPrimaryInfo+;
+#pragma link C++ class SLArMCPrimaryInfo<SLArEventTrajectory*>+;
+#pragma link C++ class SLArMCPrimaryInfo<std::unique_ptr<SLArEventTrajectory>>+;
+#pragma link C++ typedef SLArMCPrimaryInfoPtr+;
+#pragma link C++ typedef SLArMCPrimaryInfoUniquePtr+;
 #endif
 

--- a/G4SOLAr/include/physics/SLArElectronDrift.hh
+++ b/G4SOLAr/include/physics/SLArElectronDrift.hh
@@ -13,7 +13,6 @@
 #include <functional>
 #include "G4ThreeVector.hh"
 
-class SLArEventAnode; 
 class SLArCfgAnode;
 
 class SLArElectronDrift {
@@ -24,9 +23,10 @@ class SLArElectronDrift {
     void SetElectricField(double E); 
     void ComputeProperties(); 
 
+    template<class A>
     void Drift(const int& n, const int& trkId, const G4ThreeVector& pos, 
         const double time, 
-        SLArCfgAnode* anodeCfg, SLArEventAnode* anodeEv);
+        SLArCfgAnode* anodeCfg, A anodeEv);
 
     void PrintProperties(); 
 

--- a/G4SOLAr/include/physics/SLArElectronDrift.hh
+++ b/G4SOLAr/include/physics/SLArElectronDrift.hh
@@ -14,6 +14,7 @@
 #include "G4ThreeVector.hh"
 
 class SLArCfgAnode;
+class SLArEventAnode;
 
 class SLArElectronDrift {
   public:
@@ -23,10 +24,9 @@ class SLArElectronDrift {
     void SetElectricField(double E); 
     void ComputeProperties(); 
 
-    template<class A>
     void Drift(const int& n, const int& trkId, const G4ThreeVector& pos, 
         const double time, 
-        SLArCfgAnode* anodeCfg, A anodeEv);
+        SLArCfgAnode* anodeCfg, SLArEventAnode* anodeEv);
 
     void PrintProperties(); 
 

--- a/G4SOLAr/include/physics/SLArIonAndScintLArQL.h
+++ b/G4SOLAr/include/physics/SLArIonAndScintLArQL.h
@@ -42,11 +42,14 @@ class SLArIonAndScintLArQL : public SLArIonAndScintModel {
      */
 
     //! Default Birks Law
-    double QBirks(double dE, double dx, double E_field) const; 
+    double QBirks(const double& dE, const double& dx, const double& E_field) const; 
+    double QBirks(double& dEdx, const double& E_field) const; 
     //! Correction factor for Birks Law
-    double Corr(double dE, double dx, double E_field) const;
+    double Corr(const double& dE, const double& dx, const double& E_field) const;
+    double Corr(double& dEdx, const double& E_field) const;
     //! Chi2 fit to Birks Law Correction
-    double QChi(double dE, double dx, double E_field) const; 
+    double QChi(const double& dE, const double& dx, const double& E_field) const; 
+    double QChi(double& dEdx, const double& E_field) const; 
     //! Charge yield at an infinite electric field -
     double Qinf() const; 
 
@@ -60,8 +63,10 @@ class SLArIonAndScintLArQL : public SLArIonAndScintModel {
     ~SLArIonAndScintLArQL(); // Destructor
 
     // Light and charge yield functions
-    double ComputeScintYield(double energyDeposit, double stepWidth, double electricField) const override;
-    double ComputeIonYield(double energyDeposit, double stepWidth, double electricField) const override;
+    Ion_and_Scint_t ComputeIonAndScintYield(const double& energyDeposit, const double& stepWidth, const double& electricField) const override;
+    Ion_and_Scint_t ComputeIonAndScintYield(double& dEdx, const double& electricField) const override;
+    double ComputeIonYield(const double& energy_dep, const double& hit_distance, const double& electric_field) const;
+    double ComputeIonYield(double& dEdx, const double& electric_field) const;
     double Flat() const;
 
 };

--- a/G4SOLAr/include/physics/SLArIonAndScintModel.h
+++ b/G4SOLAr/include/physics/SLArIonAndScintModel.h
@@ -13,6 +13,18 @@
 
 class G4MaterialPropertiesTable;
 
+struct Ion_and_Scint_t {
+  double ion;
+  double scint;
+
+  Ion_and_Scint_t();
+  Ion_and_Scint_t(const double& ne, const double& nph);
+
+};
+
+inline Ion_and_Scint_t::Ion_and_Scint_t() : ion(0.), scint(0.) {};
+inline Ion_and_Scint_t::Ion_and_Scint_t(const double& ne, const double& nph) : ion(ne), scint(nph) {}
+
 class SLArIonAndScintModel {
   public: 
     enum EISModel {kSeparate = 0, kLArQL = 1};
@@ -20,10 +32,9 @@ class SLArIonAndScintModel {
     SLArIonAndScintModel(const G4MaterialPropertiesTable* mpt); 
     ~SLArIonAndScintModel() {}; 
 
-    virtual double ComputeIonYield(const double energy_deposit, const double step_length, const double electric_field) const = 0; 
-    virtual double ComputeScintYield(const double energy_deposit, const double step_length, const double electric_field) const = 0;
-    virtual double ComputeIon(const double energy_deposit, const double step_length, const double electric_field) const;
-    virtual double ComputeScint(const double energy_deposit, const double step_length, const double electric_field) const;
+    virtual Ion_and_Scint_t ComputeIonAndScintYield(const double& energy_deposit, const double& step_length, const double& electric_field) const = 0; 
+    virtual Ion_and_Scint_t ComputeIonAndScintYield(double& dEdx, const double& electric_field) const = 0; 
+    virtual Ion_and_Scint_t ComputeIonAndScint(const double& energy_deposit, const double& step_length, const double& electric_field) const;
 
   protected: 
     const double fWion; 

--- a/G4SOLAr/include/physics/SLArIonAndScintSeparate.h
+++ b/G4SOLAr/include/physics/SLArIonAndScintSeparate.h
@@ -23,10 +23,9 @@ class SLArIonAndScintSeparate : public SLArIonAndScintModel {
     SLArIonAndScintSeparate(const G4MaterialPropertiesTable* mpt);
     ~SLArIonAndScintSeparate() {}; 
 
-    double ComputeIonYield(const double energy_deposit, const double step_length, const double electric_field) const override; 
-    double ComputeScintYield(const double energy_deposit, const double step_length, const double electric_field) const override; 
-    double ComputeIon(const double energy_deposit, const double step_length, const double electric_field) const override; 
-    double ComputeScint(const double energy_deposit, const double step_length, const double electric_field) const override; 
+    Ion_and_Scint_t ComputeIonAndScintYield(const double& energy_deposit, const double& step_length, const double& electric_field) const override; 
+    Ion_and_Scint_t ComputeIonAndScintYield(double& dEdx, const double& electric_field) const override; 
+    Ion_and_Scint_t ComputeIonAndScint(const double& energy_deposit, const double& step_length, const double& electric_field) const override; 
     void SetLightYield(const double ly) {fLightYield = ly;}
 }; 
 

--- a/G4SOLAr/include/physics/SLArScintillation.h
+++ b/G4SOLAr/include/physics/SLArScintillation.h
@@ -212,9 +212,8 @@ class SLArScintillation : public G4VRestDiscreteProcess
   G4bool fTrackSecondariesFirst;
   G4bool fFiniteRiseTime;
 
-#ifdef G4DEBUG_SCINTILLATION
-  G4double ScintTrackEDep, ScintTrackYield;
-#endif
+  G4double ScintTrackEDep;
+  G4double ScintTrackYield;
 
   G4double single_exp(G4double t, G4double tau2);
   G4double bi_exp(G4double t, G4double tau1, G4double tau2);

--- a/G4SOLAr/solar_sim.cc
+++ b/G4SOLAr/solar_sim.cc
@@ -208,7 +208,7 @@ int main(int argc,char** argv)
   // Seed the random number generator manually
   G4Random::setTheSeed(myseed);
 
-  //G4String physName = "FTFP_BERT_HP";
+  //G4String physName = "FTFP_BERT";
   G4String physName = "QGSP_BIC_AllHP";
 
   // Set mandatory initialization classes

--- a/G4SOLAr/src/SLArAnalysisManager.cc
+++ b/G4SOLAr/src/SLArAnalysisManager.cc
@@ -71,7 +71,7 @@ SLArAnalysisManager::SLArAnalysisManager(G4bool isMaster)
   }
   if ( isMaster ) {
     fgMasterInstance = this;
-    fMCEvent         = std::make_unique<SLArMCEventPtr>();
+    fMCEvent         = new SLArMCEventPtr();
     fAnaMsgr         = new SLArAnalysisManagerMsgr();
   }
   fgInstance = this;
@@ -119,9 +119,9 @@ G4bool SLArAnalysisManager::CreateFileStructure()
 
   printf("SLArAnalysisManager: setting up output tree\n");
 
-  SLArMCEventPtr* evPtr = fMCEvent.get();
+  //SLArMCEventPtr* evPtr = fMCEvent.get();
 
-  fEventTree->Branch("MCEvent", "SLArMCEventPtr", &evPtr);
+  fEventTree->Branch("MCEvent", "SLArMCEventPtr", &fMCEvent);
   getchar();
 
   return true;

--- a/G4SOLAr/src/SLArAnalysisManager.cc
+++ b/G4SOLAr/src/SLArAnalysisManager.cc
@@ -510,14 +510,9 @@ void SLArAnalysisManager::SetupBacktrackerRecords() {
   // charge backtrackers 
   if (fChargeBacktrackerManager) {
     if (fChargeBacktrackerManager->IsNull() == false) {
-
       for (auto& evAnode : fMCEvent->GetEventAnode()) {
-        printf("SLArAnalysisManager::SetupBacktrackerRecordSize for charge readout system to %lu\n", 
-            fChargeBacktrackerManager->GetConstBacktrackers().size());
-        evAnode.second->SetChargeBacktrackerRecordSize( fChargeBacktrackerManager->GetConstBacktrackers().size() ); 
+        evAnode.second.SetChargeBacktrackerRecordSize( fChargeBacktrackerManager->GetConstBacktrackers().size() ); 
       }
-
-      getchar();
     }
   }
 
@@ -525,7 +520,7 @@ void SLArAnalysisManager::SetupBacktrackerRecords() {
   if (fVUVSiPMBacktrackerManager) {
     if (fVUVSiPMBacktrackerManager->IsNull() == false) {
       for (auto& evAnode : fMCEvent->GetEventAnode()) {
-        evAnode.second->SetLightBacktrackerRecordSize( fVUVSiPMBacktrackerManager->GetConstBacktrackers().size() );
+        evAnode.second.SetLightBacktrackerRecordSize( fVUVSiPMBacktrackerManager->GetConstBacktrackers().size() );
       }
     }
   }
@@ -534,7 +529,7 @@ void SLArAnalysisManager::SetupBacktrackerRecords() {
   if (fSuperCellBacktrackerManager) {
     if (fSuperCellBacktrackerManager->IsNull() == false) {
       for (auto& evSCA : fMCEvent->GetEventSuperCellArray() ) {
-        evSCA.second->SetLightBacktrackerRecordSize( fSuperCellBacktrackerManager->GetConstBacktrackers().size() ); 
+        evSCA.second.SetLightBacktrackerRecordSize( fSuperCellBacktrackerManager->GetConstBacktrackers().size() ); 
       }
     }
   }

--- a/G4SOLAr/src/SLArAnalysisManager.cc
+++ b/G4SOLAr/src/SLArAnalysisManager.cc
@@ -71,8 +71,9 @@ SLArAnalysisManager::SLArAnalysisManager(G4bool isMaster)
   }
   if ( isMaster ) {
     fgMasterInstance = this;
-    fMCEvent         = new SLArMCEventPtr();
-    fAnaMsgr         = new SLArAnalysisManagerMsgr();
+    fMCEvent = new SLArMCEventUniquePtr();
+    fMCEventRecord = new SLArMCEventPtr();               
+    fAnaMsgr = new SLArAnalysisManagerMsgr();
   }
   fgInstance = this;
 }
@@ -121,7 +122,7 @@ G4bool SLArAnalysisManager::CreateFileStructure()
 
   //SLArMCEventPtr* evPtr = fMCEvent.get();
 
-  fEventTree->Branch("MCEvent", "SLArMCEventPtr", &fMCEvent);
+  fEventTree->Branch("MCEvent", "SLArMCEventUniquePtr", &fMCEvent);
   getchar();
 
   return true;

--- a/G4SOLAr/src/SLArAnalysisManager.cc
+++ b/G4SOLAr/src/SLArAnalysisManager.cc
@@ -54,6 +54,7 @@ SLArAnalysisManager::SLArAnalysisManager(G4bool isMaster)
   : fAnaMsgr  (nullptr),
     fIsMaster(isMaster), fOutputPath(""),
     fOutputFileName("solarsim_output.root"), 
+    fTrajectoryFull( true ),
     fRootFile (nullptr), fEventTree (nullptr), 
     fMCEvent(nullptr),
     fSuperCellBacktrackerManager(nullptr), 

--- a/G4SOLAr/src/SLArAnalysisManager.cc
+++ b/G4SOLAr/src/SLArAnalysisManager.cc
@@ -93,8 +93,8 @@ SLArAnalysisManager::~SLArAnalysisManager()
   if (fChargeBacktrackerManager) delete fChargeBacktrackerManager;
   if (fVUVSiPMBacktrackerManager) delete fVUVSiPMBacktrackerManager;
   if (fSuperCellBacktrackerManager) delete fSuperCellBacktrackerManager;
-  if ( this->fIsMaster ) fgMasterInstance = nullptr;
-  if ( fAnaMsgr        ) delete  fAnaMsgr  ; 
+  if (this->fIsMaster) fgMasterInstance = nullptr;
+  if (fAnaMsgr) delete  fAnaMsgr; 
   fgInstance = nullptr;
   G4cerr << "SLArAnalysisManager DONE" << G4endl;
 }
@@ -112,7 +112,17 @@ G4bool SLArAnalysisManager::CreateFileStructure()
     return false;
   }
   fEventTree = new TTree("EventTree", "SoLAr-sim Simulated Events");
+ 
+  // setup backtracker size
+  SetupBacktrackerRecords(); 
 
+  printf("setting up ROOT TTree Branch...\n");
+  fEventTree->Branch("MCEvent", &fMCEvent);
+
+  return true;
+}
+
+G4bool SLArAnalysisManager::CreateEventStructure() {
   printf("fMCEvent pointer: %p\n", static_cast<void*>(fMCEvent));
 
   printf("configuring anode...\n");
@@ -120,12 +130,6 @@ G4bool SLArAnalysisManager::CreateFileStructure()
 
   printf("configuring PDS...\n");
   if (fPDSysCfg) fMCEvent->ConfigSuperCellSystem(fPDSysCfg);
-  
-  // setup backtracker size
-  SetupBacktrackerRecords(); 
-
-  printf("setting up ROOT TTree Branch...\n");
-  fEventTree->Branch("MCEvent", &fMCEvent);
 
   return true;
 }

--- a/G4SOLAr/src/SLArAnalysisManagerMsgr.cc
+++ b/G4SOLAr/src/SLArAnalysisManagerMsgr.cc
@@ -31,7 +31,8 @@ SLArAnalysisManagerMsgr::SLArAnalysisManagerMsgr() :
   fCmdWriteCfgFile(nullptr), fCmdPlotXSec(nullptr), 
   fCmdGeoAnodeDepth(nullptr), 
   fCmdEnableBacktracker(nullptr),
-  fCmdRegisterBacktracker(nullptr)
+  fCmdRegisterBacktracker(nullptr), 
+  fCmdSetZeroSuppressionThrs(nullptr)
 #ifdef SLAR_GDML
   ,fCmdGDMLFileName(nullptr), fCmdGDMLExport(nullptr), 
   fGDMLFileName("slar_export.gdml")
@@ -79,9 +80,14 @@ SLArAnalysisManagerMsgr::SLArAnalysisManagerMsgr() :
 
   fCmdRegisterBacktracker = 
     new G4UIcmdWithAString(UIManagerPath+"registerBacktracker", this);
-  fCmdRegisterBacktracker->SetGuidance("rnable backtracker on readout system");
+  fCmdRegisterBacktracker->SetGuidance("Add backtracker on readout system");
   fCmdRegisterBacktracker->SetParameterName("backtraker_system", false);
   fCmdRegisterBacktracker->SetGuidance("Specfiy readout system and backtracker [readout_system]:[backtraker]");
+
+  fCmdSetZeroSuppressionThrs = 
+    new G4UIcmdWithAnInteger(UIManagerPath+"setZeroSuppressionThrs", this);
+  fCmdSetZeroSuppressionThrs->SetGuidance("Set charge readout zero suppression threshold");
+  fCmdSetZeroSuppressionThrs->SetParameterName("threshold", false);
   
   fCmdGeoAnodeDepth = 
     new G4UIcmdWithAnInteger(UIGeometryPath+"setAnodeVisDepth", this);
@@ -114,6 +120,7 @@ SLArAnalysisManagerMsgr::~SLArAnalysisManagerMsgr()
   if (fCmdGeoAnodeDepth      ) delete fCmdGeoAnodeDepth      ; 
   if (fCmdEnableBacktracker  ) delete fCmdEnableBacktracker  ;
   if (fCmdRegisterBacktracker) delete fCmdRegisterBacktracker;
+  if (fCmdSetZeroSuppressionThrs) delete fCmdSetZeroSuppressionThrs;
 #ifdef SLAR_DGML
   if (fCmdGDMLFileName  ) delete fCmdGDMLFileName  ;
   if (fCmdGDMLExport    ) delete fCmdGDMLExport    ;
@@ -189,6 +196,12 @@ void SLArAnalysisManagerMsgr::SetNewValue
 
     auto bkt_mngr = SLArAnaMgr->GetBacktrackerManager(_system);
     bkt_mngr->RegisterBacktracker(backtracker::GetBacktrackerEnum(_backtracker), _name);
+  }
+  else if (cmd == fCmdSetZeroSuppressionThrs) {
+    int thrs = std::atoi( newVal ); 
+    for (auto& anode_itr : SLArAnaMgr->GetEvent()->GetEventAnode()) {
+      anode_itr.second.SetZeroSuppressionThreshold( thrs ); 
+    }
   }
 #ifdef SLAR_GDML
   else if (cmd == fCmdGDMLFileName) {

--- a/G4SOLAr/src/SLArAnalysisManagerMsgr.cc
+++ b/G4SOLAr/src/SLArAnalysisManagerMsgr.cc
@@ -82,7 +82,6 @@ SLArAnalysisManagerMsgr::SLArAnalysisManagerMsgr() :
   fCmdRegisterBacktracker->SetGuidance("rnable backtracker on readout system");
   fCmdRegisterBacktracker->SetParameterName("backtraker_system", false);
   fCmdRegisterBacktracker->SetGuidance("Specfiy readout system and backtracker [readout_system]:[backtraker]");
-  fCmdRegisterBacktracker->SetCandidates("trkID ancestorID opticalProc");
   
   fCmdGeoAnodeDepth = 
     new G4UIcmdWithAnInteger(UIGeometryPath+"setAnodeVisDepth", this);

--- a/G4SOLAr/src/SLArAnalysisManagerMsgr.cc
+++ b/G4SOLAr/src/SLArAnalysisManagerMsgr.cc
@@ -71,6 +71,10 @@ SLArAnalysisManagerMsgr::SLArAnalysisManagerMsgr() :
   fCmdPlotXSec->SetParameterName("xsec_spec", false);
   fCmdPlotXSec->SetGuidance("Specfiy [particle]:[process]:[material]:[log(0-1)]");
 
+  fCmdStoreFullTrajectory = 
+    new G4UIcmdWithABool(UIManagerPath+"storeFullTrajectory", this);
+  fCmdStoreFullTrajectory->SetGuidance("Store full track trajectory");
+
   fCmdEnableBacktracker = 
     new G4UIcmdWithAString(UIManagerPath+"enableBacktracker", this);
   fCmdEnableBacktracker->SetGuidance("Enable backtracker on readout system");
@@ -118,6 +122,7 @@ SLArAnalysisManagerMsgr::~SLArAnalysisManagerMsgr()
   if (fCmdWriteCfgFile       ) delete fCmdWriteCfgFile       ; 
   if (fCmdPlotXSec           ) delete fCmdPlotXSec           ; 
   if (fCmdGeoAnodeDepth      ) delete fCmdGeoAnodeDepth      ; 
+  if (fCmdStoreFullTrajectory) delete fCmdStoreFullTrajectory;
   if (fCmdEnableBacktracker  ) delete fCmdEnableBacktracker  ;
   if (fCmdRegisterBacktracker) delete fCmdRegisterBacktracker;
   if (fCmdSetZeroSuppressionThrs) delete fCmdSetZeroSuppressionThrs;
@@ -174,6 +179,9 @@ void SLArAnalysisManagerMsgr::SetNewValue
   }
   else if (cmd == fCmdGeoAnodeDepth) {
     fConstr_->SetAnodeVisAttributes( std::atoi(newVal) ); 
+  }
+  else if (cmd == fCmdStoreFullTrajectory) {
+    SLArAnaMgr->SetStoreTrajectoryFull( G4UIcmdWithABool::GetNewBoolValue(newVal) );
   }
   else if (cmd == fCmdEnableBacktracker) {
     SLArAnaMgr->ConstructBacktracker( newVal );

--- a/G4SOLAr/src/SLArAnalysisManagerMsgr.cc
+++ b/G4SOLAr/src/SLArAnalysisManagerMsgr.cc
@@ -82,7 +82,7 @@ SLArAnalysisManagerMsgr::SLArAnalysisManagerMsgr() :
   fCmdRegisterBacktracker->SetGuidance("rnable backtracker on readout system");
   fCmdRegisterBacktracker->SetParameterName("backtraker_system", false);
   fCmdRegisterBacktracker->SetGuidance("Specfiy readout system and backtracker [readout_system]:[backtraker]");
-  fCmdRegisterBacktracker->SetCandidates("trkID anchestorID opticalProc");
+  fCmdRegisterBacktracker->SetCandidates("trkID ancestorID opticalProc");
   
   fCmdGeoAnodeDepth = 
     new G4UIcmdWithAnInteger(UIGeometryPath+"setAnodeVisDepth", this);

--- a/G4SOLAr/src/SLArBacktracker.cc
+++ b/G4SOLAr/src/SLArBacktracker.cc
@@ -43,7 +43,7 @@ EBacktracker GetBacktrackerEnum(const G4String bkt) {
     id = kTrkID;
   }
   else if (bkt == "ancestorID") {
-    id = kAnchestorID;
+    id = kAncestorID;
   }
   else if (bkt == "opticalProc") {
     id = kOpticalProc;

--- a/G4SOLAr/src/SLArBacktrackerManager.cc
+++ b/G4SOLAr/src/SLArBacktrackerManager.cc
@@ -57,6 +57,10 @@ G4bool SLArBacktrackerManager::RegisterBacktracker(const EBacktracker id, const 
       }
   }
 
+  printf("SLArBacktrackerManager::Registered backtracker %s with status [%i]\n", 
+      BacktrackerLabel[id].data(), status);
+  //getchar();
+
   return status;
 }
 

--- a/G4SOLAr/src/SLArBacktrackerManager.cc
+++ b/G4SOLAr/src/SLArBacktrackerManager.cc
@@ -37,7 +37,7 @@ G4bool SLArBacktrackerManager::RegisterBacktracker(const EBacktracker id, const 
         status = true;
         break;
       }
-    case kAnchestorID:
+    case kAncestorID:
       {
         if (name.empty()) bkt_name = BacktrackerLabel[id];
         fBacktrackers.push_back( new SLArBacktrackerAncestorID( bkt_name ));

--- a/G4SOLAr/src/SLArDetectorConstruction.cc
+++ b/G4SOLAr/src/SLArDetectorConstruction.cc
@@ -463,7 +463,7 @@ G4VPhysicalVolume* SLArDetectorConstruction::Construct()
     = new G4PVPlacement(0,G4ThreeVector(),fWorldLog,"World",0,false,0);
 
   // 2. Build and place the LAr target
-  G4cerr << "\nSLArDetectorConstruction: Building the Detector Volume" << G4endl;
+  G4cout << "\nSLArDetectorConstruction: Building the Detector Volume" << G4endl;
   fDetector->SetModPV( new G4PVPlacement(0, 
         G4ThreeVector(fDetector->GetGeoPar("det_pos_x"), 
           fDetector->GetGeoPar("det_pos_y"), 
@@ -471,14 +471,14 @@ G4VPhysicalVolume* SLArDetectorConstruction::Construct()
         fDetector->GetModLV(), "target_lar_pv", fWorldLog, 0, 9) ); 
   
   // 3. Build and place the Cryostat
-  G4cerr << "\nSLArDetectorConstruction: Building the Cryostat" << G4endl;
+  G4cout << "\nSLArDetectorConstruction: Building the Cryostat" << G4endl;
   fCryostat->SetWorldMaterial(matWorld); 
   ConstructCryostat(); 
 
-  G4cerr << "\nSLArDetectorConstruction: Building the Cathode" << G4endl;
+  G4cout << "\nSLArDetectorConstruction: Building the Cathode" << G4endl;
   ConstructCathode(); 
 
-  G4cerr << "\nSLArDetectorConstruction: Building the TPCs" << G4endl;
+  G4cout << "\nSLArDetectorConstruction: Building the TPCs" << G4endl;
   for (auto &tpc : fTPC) {
     tpc.second->BuildMaterial(fMaterialDBFile); 
     tpc.second->BuildTPC();
@@ -501,6 +501,9 @@ G4VPhysicalVolume* SLArDetectorConstruction::Construct()
   G4VisAttributes* visAttributes = new G4VisAttributes();
   visAttributes->SetColor(0.25,0.54,0.79, 0.0);
   fWorldLog->SetVisAttributes(visAttributes);
+
+  
+  SLArAnalysisManager::Instance()->CreateEventStructure();
 
   //always return the physical World
   return fWorldPhys;

--- a/G4SOLAr/src/SLArEventAction.cc
+++ b/G4SOLAr/src/SLArEventAction.cc
@@ -158,9 +158,9 @@ void SLArEventAction::EndOfEventAction(const G4Event* event)
     auto& primaries = slar_event->GetPrimaries();
     for (const auto &p : primaries ) {
       printf("%s - %g MeV - trk ID %i\n", 
-          p->GetParticleName().Data(), p->GetEnergy(), p->GetTrackID());
+          p.GetParticleName().Data(), p.GetEnergy(), p.GetTrackID());
       printf("\t%i scintillation ph\n\t%i Cerenkov photons\n", 
-          p->GetTotalScintPhotons(), p->GetTotalCerenkovPhotons()); 
+          p.GetTotalScintPhotons(), p.GetTotalCerenkovPhotons()); 
       printf("ReadoutTile Hits: %i\nSuperCell Hits: %i\n\n", 
           fReadoutTileHits, fSuperCellHits);
     }
@@ -237,13 +237,13 @@ void SLArEventAction::RecordEventReadoutTile(const G4Event* ev)
       dstHit.SetCellNr(hit->GetCellNr()); 
       dstHit.SetProducerTrkID( hit->GetProducerID() ); 
 
-      auto ev_anode = SLArAnaMgr->GetEvent()->GetEventAnodeByID(anode_idx);
-      auto ev_tile = ev_anode->RegisterHit(dstHit);
+      auto& ev_anode = SLArAnaMgr->GetEvent()->GetEventAnodeByID(anode_idx);
+      auto& ev_tile = ev_anode.RegisterHit(dstHit);
 
       if (bktManager) {
         if (bktManager->IsNull() == false) {
           auto records = 
-            ev_tile->GetBacktrackerVector( ev_tile->ConvertToClock(dstHit.GetTime()) );
+            ev_tile.GetBacktrackerVector( ev_tile.ConvertToClock(dstHit.GetTime()) );
 
           for (size_t ib = 0; ib < bktManager->GetBacktrackers().size(); ib++) {
             bktManager->GetBacktrackers().at(ib)->Eval(&dstHit, 
@@ -330,12 +330,12 @@ void SLArEventAction::RecordEventSuperCell(const G4Event* ev)
       dstHit.SetTileInfo(0, array_nr, cellrow_nr, cell_nr); 
       dstHit.SetProducerTrkID( hit->GetProducerID() ); 
 
-      auto ev_sc = SLArAnaMgr->GetEvent()->GetEventSuperCellArray(array_nr)->RegisterHit(dstHit);
+      auto& ev_sc = SLArAnaMgr->GetEvent()->GetEventSuperCellArray(array_nr).RegisterHit(dstHit);
 
       if (bktManager) {
         if (bktManager->IsNull() == false) {
           SLArEventBacktrackerVector& records = 
-            ev_sc->GetBacktrackerVector( ev_sc->ConvertToClock<float>(dstHit.GetTime()) );
+            ev_sc.GetBacktrackerVector( ev_sc.ConvertToClock<float>(dstHit.GetTime()) );
 
           for (size_t ib = 0; ib < bktManager->GetBacktrackers().size(); ib++) {
             bktManager->GetBacktrackers().at(ib)->Eval(&dstHit, 
@@ -424,7 +424,7 @@ int SLArEventAction::FindAncestorID(int trkid) {
 #endif
 
     for (const auto& p : primaries) {
-      if (pid == p->GetTrackID()) {
+      if (pid == p.GetTrackID()) {
         primary = pid; 
         caught = true;
       }

--- a/G4SOLAr/src/SLArEventAction.cc
+++ b/G4SOLAr/src/SLArEventAction.cc
@@ -141,12 +141,13 @@ void SLArEventAction::EndOfEventAction(const G4Event* event)
     auto slar_event = SLArAnaMgr->GetEvent();
     slar_event->SetEvNumber(event->GetEventID());
 
-    //for (const auto &evAnode : slar_event->GetEventAnode()) {
-      //printf("ANODE %i\n", evAnode.first);
-      //for (const auto &evMT : evAnode.second->GetConstMegaTilesMap()) {
-        //printf("\tMEGATILE %i\n", evMT.first);
-      //}
-    //}
+    // apply zero suppression to charge signal
+    for (auto &evAnode : slar_event->GetEventAnode()) {
+      short thrs = evAnode.second.GetZeroSuppressionThreshold(); 
+      if (thrs > 0) {
+        evAnode.second.ApplyZeroSuppression();
+      }
+    }
     
     SLArAnaMgr->FillEvTree();
     

--- a/G4SOLAr/src/SLArEventAction.cc
+++ b/G4SOLAr/src/SLArEventAction.cc
@@ -196,7 +196,6 @@ void SLArEventAction::RecordEventReadoutTile(const G4Event* ev)
 
     // Fill histograms
     G4int n_hit = hHC1->entries();
-    printf("SLArEventAction::RecordEventReadoutTile() Recording %i hits\n\n", n_hit);
 
     for (G4int i=0;i<n_hit;i++) {
       SLArReadoutTileHit* hit = (*hHC1)[i];
@@ -212,13 +211,13 @@ void SLArEventAction::RecordEventReadoutTile(const G4Event* ev)
 
       G4ThreeVector localPos = hit->GetLocalPos();
       G4ThreeVector worldPos = hit->GetWorldPos();
-      G4double      time     = hit->GetTime();
-      G4double      wavelen  = hit->GetPhotonWavelength(); 
-      G4int         anode_idx = hit->GetAnodeIdx();
-      G4int         mtrow_nr  = hit->GetRowMegaTileIdx(); 
-      G4int         mgtile_nr = hit->GetMegaTileIdx(); 
-      G4int         rowtile_nr = hit->GetRowTileIdx(); 
-      G4int         tile_nr    = hit->GetTileIdx(); 
+      G4double time = hit->GetTime();
+      G4double wavelen = hit->GetPhotonWavelength(); 
+      G4int anode_idx = hit->GetAnodeIdx();
+      G4int mtrow_nr = hit->GetRowMegaTileIdx(); 
+      G4int mgtile_nr = hit->GetMegaTileIdx(); 
+      G4int rowtile_nr = hit->GetRowTileIdx(); 
+      G4int tile_nr = hit->GetTileIdx(); 
 
 #ifdef SLAR_DEBUG
       G4cout << "SLArEventAction::RecordEventReadoutTile() hit nr " << i << G4endl;

--- a/G4SOLAr/src/SLArEventAction.cc
+++ b/G4SOLAr/src/SLArEventAction.cc
@@ -26,6 +26,7 @@
 #include "G4Trajectory.hh"
 
 #include "G4ios.hh"
+#include <cstdio>
 
 
 //....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
@@ -64,20 +65,20 @@ void SLArEventAction::BeginOfEventAction(const G4Event*)
 #endif
 
   G4SDManager* sdManager = G4SDManager::GetSDMpointer();
-    if (fTileHCollID == -2) 
-      fTileHCollID  = sdManager->GetCollectionID("ReadoutTileColl"  );
-    if (fSuperCellHCollID == -5) 
-      fSuperCellHCollID = sdManager->GetCollectionID("SuperCellColl"); 
-    if (fLArHCollID.empty()) {
-      auto detConstruction = (SLArDetectorConstruction*)
-        G4RunManager::GetRunManager()->GetUserDetectorConstruction(); 
-      for (const auto &tpc : detConstruction->GetDetTPCs() ) {
-        auto coll_id = 
-          sdManager->GetCollectionID("TPC"+std::to_string(tpc.first)+"Coll");
-        fLArHCollID.push_back(coll_id); 
-      }
+  if (fTileHCollID == -2) 
+    fTileHCollID  = sdManager->GetCollectionID("ReadoutTileColl"  );
+  if (fSuperCellHCollID == -5) 
+    fSuperCellHCollID = sdManager->GetCollectionID("SuperCellColl"); 
+  if (fLArHCollID.empty()) {
+    auto detConstruction = (SLArDetectorConstruction*)
+      G4RunManager::GetRunManager()->GetUserDetectorConstruction(); 
+    for (const auto &tpc : detConstruction->GetDetTPCs() ) {
+      auto coll_id = 
+        sdManager->GetCollectionID("TPC"+std::to_string(tpc.first)+"Coll");
+      fLArHCollID.push_back(coll_id); 
     }
-     
+  }
+
 
 #ifdef SLAR_DEBUG
     G4cout << "SLArEventAction::BeginOfEventAction():" << G4endl;
@@ -124,7 +125,7 @@ void SLArEventAction::EndOfEventAction(const G4Event* event)
     }   
     SLArAnalysisManager* SLArAnaMgr = SLArAnalysisManager::Instance();
 
-    RecordEventLAr( event );
+    //RecordEventLAr( event );
 
     if ( !SLArAnaMgr->GetAnodeCfg().empty() ) {
       RecordEventReadoutTile ( event );
@@ -138,14 +139,24 @@ void SLArEventAction::EndOfEventAction(const G4Event* event)
 
      
     SLArAnaMgr->GetEvent()->SetEvNumber(event->GetEventID());
+
+    for (const auto &evAnode : SLArAnaMgr->GetEvent()->GetEventAnode()) {
+      printf("ANODE %i\n", evAnode.first);
+      for (const auto &evMT : evAnode.second->GetConstMegaTilesMap()) {
+        printf("\tMEGATILE %i\n", evMT.first);
+      }
+
+    }
     
     SLArAnaMgr->FillEvTree();
+    
 
     printf("SLArEventAction::EndOfEventAction()\n"); 
     printf("OpticalPhoton Monitor:\nCherenkov: %i\nScintillation: %i\n\n", 
         fPhotonCount_Cher, fPhotonCount_Scnt);
     printf("Primary particles:\n");
-    for (const auto &p : SLArAnaMgr->GetEvent()->GetPrimaries()) {
+    auto& primaries = SLArAnaMgr->GetEvent()->GetPrimaries();
+    for (const auto &p : primaries ) {
       printf("%s - %g MeV - trk ID %i\n", 
           p->GetParticleName().Data(), p->GetEnergy(), p->GetTrackID());
       printf("\t%i scintillation ph\n\t%i Cerenkov photons\n", 
@@ -185,6 +196,7 @@ void SLArEventAction::RecordEventReadoutTile(const G4Event* ev)
 
     // Fill histograms
     G4int n_hit = hHC1->entries();
+    printf("SLArEventAction::RecordEventReadoutTile() Recording %i hits\n\n", n_hit);
 
     for (G4int i=0;i<n_hit;i++) {
       SLArReadoutTileHit* hit = (*hHC1)[i];
@@ -209,39 +221,38 @@ void SLArEventAction::RecordEventReadoutTile(const G4Event* ev)
       G4int         tile_nr    = hit->GetTileIdx(); 
 
 #ifdef SLAR_DEBUG
-      G4cout << "SLArEventAction::RecordEventReadoutTile()" << G4endl;
+      G4cout << "SLArEventAction::RecordEventReadoutTile() hit nr " << i << G4endl;
       printf("Tile idx [%i, %i, %i, %i]\n", mtrow_nr, mgtile_nr, rowtile_nr, tile_nr);
       G4cout << "x    = " << G4BestUnit(worldPos.x(), "Length") << "; "
              << "y    = " << G4BestUnit(worldPos.y(), "Length") << "; "
              << "time = " << G4BestUnit(time, "Time") << G4endl;
 #endif
       
-      SLArEventPhotonHit* dstHit = new SLArEventPhotonHit(
+      SLArEventPhotonHit dstHit(
           time, 
           hit->GetPhotonProcessId(), 
           wavelen);
-      dstHit->SetLocalPos(localPos.x(), localPos.y(), localPos.z());
-      dstHit->SetTileInfo(mtrow_nr, mgtile_nr, rowtile_nr, tile_nr); 
-      dstHit->SetRowCellNr(hit->GetRowCellNr()); 
-      dstHit->SetCellNr(hit->GetCellNr()); 
-      dstHit->SetProducerTrkID( hit->GetProducerID() ); 
+      dstHit.SetLocalPos(localPos.x(), localPos.y(), localPos.z());
+      dstHit.SetTileInfo(mtrow_nr, mgtile_nr, rowtile_nr, tile_nr); 
+      dstHit.SetRowCellNr(hit->GetRowCellNr()); 
+      dstHit.SetCellNr(hit->GetCellNr()); 
+      dstHit.SetProducerTrkID( hit->GetProducerID() ); 
 
-      auto ev_anode = SLArAnaMgr->GetEvent()->GetEventAnodeByID(anode_idx);
-      auto ev_tile = ev_anode->RegisterHit(dstHit);
+      auto& ev_anode = SLArAnaMgr->GetEvent()->GetEventAnodeByID(anode_idx);
+      auto& ev_tile = ev_anode->RegisterHit(dstHit);
 
       if (bktManager) {
         if (bktManager->IsNull() == false) {
           SLArEventBacktrackerVector* records = 
-            ev_tile->GetBacktrackerVector( ev_tile->ConvertToClock<float>(dstHit->GetTime()) );
+            ev_tile->GetBacktrackerVector( ev_tile->ConvertToClock<float>(dstHit.GetTime()) );
 
           for (size_t ib = 0; ib < bktManager->GetBacktrackers().size(); ib++) {
-            bktManager->GetBacktrackers().at(ib)->Eval(dstHit, 
+            bktManager->GetBacktrackers().at(ib)->Eval(&dstHit, 
                 &records->GetRecords().at(ib));
           }
         }
       }
       
-      delete dstHit;
     }
 
     // Sort hits on PMTs
@@ -320,7 +331,7 @@ void SLArEventAction::RecordEventSuperCell(const G4Event* ev)
       dstHit.SetTileInfo(0, array_nr, cellrow_nr, cell_nr); 
       dstHit.SetProducerTrkID( hit->GetProducerID() ); 
 
-      auto ev_sc = SLArAnaMgr->GetEvent()->GetEventSuperCellArray(array_nr)->RegisterHit(&dstHit);
+      auto& ev_sc = SLArAnaMgr->GetEvent()->GetEventSuperCellArray(array_nr)->RegisterHit(dstHit);
 
       if (bktManager) {
         if (bktManager->IsNull() == false) {
@@ -336,6 +347,7 @@ void SLArEventAction::RecordEventSuperCell(const G4Event* ev)
       
       //delete dstHit;
     }
+    
 
     // Sort hits on PMTs
     //printf("Sorting hits...\n"); 
@@ -355,9 +367,9 @@ void SLArEventAction::RecordEventSuperCell(const G4Event* ev)
 
 void SLArEventAction::RecordEventLAr(const G4Event* ev)
 {
-#ifdef SLAR_DEBUG
-  printf("  -> RecordEventLAr()\n");
-#endif
+//#ifdef SLAR_DEBUG
+  //printf("  -> RecordEventLAr()\n");
+//#endif
 
   G4HCofThisEvent* hce = ev->GetHCofThisEvent();
   if (fLArHCollID.empty()) return;
@@ -376,9 +388,9 @@ void SLArEventAction::RecordEventLAr(const G4Event* ev)
   }
 
 
-#ifdef SLAR_DEBUG
-  printf("     DONE\n"); 
-#endif
+//#ifdef SLAR_DEBUG
+  //printf("     DONE\n"); 
+//#endif
 }
 
 void SLArEventAction::RegisterNewTrackPID(int trk_id, int p_id) {
@@ -391,28 +403,28 @@ int SLArEventAction::FindAncestorID(int trkid) {
   int pid = trkid; 
 
   SLArAnalysisManager* anaMngr = SLArAnalysisManager::Instance(); 
-  auto primaries = anaMngr->GetEvent()->GetPrimaries(); 
+  auto& primaries = anaMngr->GetEvent()->GetPrimaries(); 
   bool caught = false; 
-//#ifdef SLAR_DEBUG
-  //printf("Lookging for primary parent of %i among\n", trkid);
-  //for (const auto& _pid : fParentIDMap) {
-    //printf("%i - PID: %i\n", _pid.first, _pid.second); 
-  //}
+#ifdef SLAR_DEBUG
+  printf("SLArEventAction::FindAncestorID() Lookging for primary parent of %i among\n", trkid);
+  for (const auto& _pid : fParentIDMap) {
+    printf("%i - PID: %i\n", _pid.first, _pid.second); 
+  }
 
-  //printf("\nList of primaries: \n");
-  //for (const auto &p : primaries) {
-    //printf("%s - PID: %i\n", p->GetParticleName().Data(), p->GetTrackID());
-  //}
+  printf("\nList of primaries: \n");
+  for (const SLArMCPrimaryInfo& p : primaries) {
+    printf("%s - PID: %i\n", p.GetParticleName().Data(), p.GetTrackID());
+  }
   //getchar(); 
-//#endif
+#endif
 
   while ( !caught ) {
     pid = fParentIDMap[trkid];
-//#ifdef SLAR_DEBUG
-    //printf("local parent id: %i\n", pid);
-//#endif
+#ifdef SLAR_DEBUG
+    printf("local parent id: %i\n", pid);
+#endif
 
-    for (const auto &p : primaries) {
+    for (const auto& p : primaries) {
       if (pid == p->GetTrackID()) {
         primary = pid; 
         caught = true;
@@ -425,10 +437,10 @@ int SLArEventAction::FindAncestorID(int trkid) {
 //#endif
   }
 
-//#ifdef SLAR_DEBUG
-  //printf("Caught! returning %i\n", primary);
+#ifdef SLAR_DEBUG
+  printf("Caught! returning %i\n", primary);
   //getchar(); 
-//#endif
+#endif
 
   return primary; 
 }

--- a/G4SOLAr/src/SLArOpticalPhysics.cc
+++ b/G4SOLAr/src/SLArOpticalPhysics.cc
@@ -70,7 +70,7 @@ void SLArOpticalPhysics::ConstructProcess()
 
   //fWLSProcess = new G4OpWLS("WLS");
 
-  fScintProcess = new SLArScintillation("Scintillation");
+  fScintProcess = new SLArScintillation("Scintillation", fOptical);
   //fScintProcess = new G4Scintillation("Scintillation");
 
   fCerenkovProcess = new G4Cerenkov("Cerenkov");

--- a/G4SOLAr/src/SLArPhysicsList.cc
+++ b/G4SOLAr/src/SLArPhysicsList.cc
@@ -42,6 +42,7 @@
 #include "G4ParticleTable.hh"
 
 //#include "G4PhysListFactory.hh"
+#include "FTFP_BERT.hh"
 #include "FTFP_BERT_HP.hh"
 #include "QGSP_BERT_HP.hh"
 #include "QGSP_BIC_AllHP.hh"
@@ -89,7 +90,7 @@ SLArPhysicsList::SLArPhysicsList(G4String physName) :
     phys = new QGSP_BIC_AllHP; 
   }
   else {
-    phys = new FTFP_BERT_HP;
+    phys = new FTFP_BERT;
   }
   //    if (factory.IsReferencePhysList(physName)) {
   //       phys = factory.GetReferencePhysList(physName);

--- a/G4SOLAr/src/SLArPrimaryGeneratorAction.cc
+++ b/G4SOLAr/src/SLArPrimaryGeneratorAction.cc
@@ -307,7 +307,7 @@ void SLArPrimaryGeneratorAction::GeneratePrimaries(G4Event* anEvent)
   printf("Primary Generator Action produced %i vertex(ices)\n", n); 
   for (int i=0; i<n; i++) {
     //std::unique_ptr<SLArMCPrimaryInfoUniquePtr> tc_primary = std::make_unique<SLArMCPrimaryInfoUniquePtr>();
-    SLArMCPrimaryInfo* tc_primary = new SLArMCPrimaryInfo();
+    SLArMCPrimaryInfo tc_primary;
     G4int np = anEvent->GetPrimaryVertex(i)->GetNumberOfParticle(); 
     //printf("vertex %i has %i particles at t = %g\n", n, np, 
         //anEvent->GetPrimaryVertex(i)->GetT0()); 
@@ -316,21 +316,21 @@ void SLArPrimaryGeneratorAction::GeneratePrimaries(G4Event* anEvent)
       auto particle = anEvent->GetPrimaryVertex(i)->GetPrimary(ip); 
 
       if (!particle->GetParticleDefinition()) {
-        tc_primary->SetID  (particle->GetPDGcode()); 
-        tc_primary->SetName("Ion");
+        tc_primary.SetID  (particle->GetPDGcode()); 
+        tc_primary.SetName("Ion");
       } else {
-        tc_primary->SetID  (particle->GetPDGcode());
-        tc_primary->SetName(particle->GetParticleDefinition()->GetParticleName());
+        tc_primary.SetID  (particle->GetPDGcode());
+        tc_primary.SetName(particle->GetParticleDefinition()->GetParticleName());
       }
 
-      tc_primary->SetTrackID(particle->GetTrackID());
-      tc_primary->SetPosition(anEvent->GetPrimaryVertex(i)->GetX0(),
+      tc_primary.SetTrackID(particle->GetTrackID());
+      tc_primary.SetPosition(anEvent->GetPrimaryVertex(i)->GetX0(),
           anEvent->GetPrimaryVertex(i)->GetY0(), 
           anEvent->GetPrimaryVertex(i)->GetZ0());
-      tc_primary->SetMomentum(
+      tc_primary.SetMomentum(
           particle->GetPx(), particle->GetPy(), particle->GetPz(), 
           particle->GetKineticEnergy());
-      tc_primary->SetTime(anEvent->GetPrimaryVertex(i)->GetT0()); 
+      tc_primary.SetTime(anEvent->GetPrimaryVertex(i)->GetT0()); 
       
 
 #ifdef SLAR_DEBUG

--- a/G4SOLAr/src/SLArPrimaryGeneratorAction.cc
+++ b/G4SOLAr/src/SLArPrimaryGeneratorAction.cc
@@ -61,7 +61,7 @@
 
 SLArPrimaryGeneratorAction::SLArPrimaryGeneratorAction()
  : G4VUserPrimaryGeneratorAction(), 
-   fGeneratorActions(6, nullptr),//--JM Change 5->6
+   fGeneratorActions(7, nullptr),//--JM Change 5->6
    fBulkGenerator(0), 
    fVolumeName(""), 
    fGeneratorEnum(kParticleGun), 
@@ -306,8 +306,8 @@ void SLArPrimaryGeneratorAction::GeneratePrimaries(G4Event* anEvent)
 
   printf("Primary Generator Action produced %i vertex(ices)\n", n); 
   for (int i=0; i<n; i++) {
-    SLArMCPrimaryInfo tc_primary;
-
+    //std::unique_ptr<SLArMCPrimaryInfoUniquePtr> tc_primary = std::make_unique<SLArMCPrimaryInfoUniquePtr>();
+    SLArMCPrimaryInfoPtr* tc_primary = new SLArMCPrimaryInfoPtr();
     G4int np = anEvent->GetPrimaryVertex(i)->GetNumberOfParticle(); 
     //printf("vertex %i has %i particles at t = %g\n", n, np, 
         //anEvent->GetPrimaryVertex(i)->GetT0()); 
@@ -316,21 +316,21 @@ void SLArPrimaryGeneratorAction::GeneratePrimaries(G4Event* anEvent)
       auto particle = anEvent->GetPrimaryVertex(i)->GetPrimary(ip); 
 
       if (!particle->GetParticleDefinition()) {
-        tc_primary.SetID  (particle->GetPDGcode()); 
-        tc_primary.SetName("Ion");
+        tc_primary->SetID  (particle->GetPDGcode()); 
+        tc_primary->SetName("Ion");
       } else {
-        tc_primary.SetID  (particle->GetPDGcode());
-        tc_primary.SetName(particle->GetParticleDefinition()->GetParticleName());
+        tc_primary->SetID  (particle->GetPDGcode());
+        tc_primary->SetName(particle->GetParticleDefinition()->GetParticleName());
       }
 
-      tc_primary.SetTrackID(particle->GetTrackID());
-      tc_primary.SetPosition(anEvent->GetPrimaryVertex(i)->GetX0(),
+      tc_primary->SetTrackID(particle->GetTrackID());
+      tc_primary->SetPosition(anEvent->GetPrimaryVertex(i)->GetX0(),
           anEvent->GetPrimaryVertex(i)->GetY0(), 
           anEvent->GetPrimaryVertex(i)->GetZ0());
-      tc_primary.SetMomentum(
+      tc_primary->SetMomentum(
           particle->GetPx(), particle->GetPy(), particle->GetPz(), 
           particle->GetKineticEnergy());
-      tc_primary.SetTime(anEvent->GetPrimaryVertex(i)->GetT0()); 
+      tc_primary->SetTime(anEvent->GetPrimaryVertex(i)->GetT0()); 
       
 
 #ifdef SLAR_DEBUG
@@ -338,7 +338,7 @@ void SLArPrimaryGeneratorAction::GeneratePrimaries(G4Event* anEvent)
       tc_primary.PrintParticle(); 
       //getchar();
 #endif
-      SLArAnaMgr->GetEvent()->RegisterPrimary(new SLArMCPrimaryInfo(tc_primary)); 
+      SLArAnaMgr->GetEvent()->RegisterPrimary( std::move(tc_primary) );
     }
   }
 
@@ -384,8 +384,9 @@ void SLArPrimaryGeneratorAction::SetGENIEEvntExt(G4int evntID) { // --JM
 }
 
 void SLArPrimaryGeneratorAction::SetGENIEFile(G4String filename) { // --JM
-  printf("Setting GENIE file as:\n\t %s.",filename);
+  printf("Setting GENIE file as:\n\t %s.",filename.data());
   fGENIEFile = filename;
+
 }
 
 //....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......

--- a/G4SOLAr/src/SLArPrimaryGeneratorAction.cc
+++ b/G4SOLAr/src/SLArPrimaryGeneratorAction.cc
@@ -306,8 +306,8 @@ void SLArPrimaryGeneratorAction::GeneratePrimaries(G4Event* anEvent)
 
   printf("Primary Generator Action produced %i vertex(ices)\n", n); 
   for (int i=0; i<n; i++) {
-    std::unique_ptr<SLArMCPrimaryInfoUniquePtr> tc_primary = std::make_unique<SLArMCPrimaryInfoUniquePtr>();
-    //SLArMCPrimaryInfoPtr* tc_primary = new SLArMCPrimaryInfoPtr();
+    //std::unique_ptr<SLArMCPrimaryInfoUniquePtr> tc_primary = std::make_unique<SLArMCPrimaryInfoUniquePtr>();
+    SLArMCPrimaryInfo* tc_primary = new SLArMCPrimaryInfo();
     G4int np = anEvent->GetPrimaryVertex(i)->GetNumberOfParticle(); 
     //printf("vertex %i has %i particles at t = %g\n", n, np, 
         //anEvent->GetPrimaryVertex(i)->GetT0()); 
@@ -338,7 +338,7 @@ void SLArPrimaryGeneratorAction::GeneratePrimaries(G4Event* anEvent)
       tc_primary.PrintParticle(); 
       //getchar();
 #endif
-      SLArAnaMgr->GetEvent()->RegisterPrimary( std::move(tc_primary) );
+      SLArAnaMgr->GetEvent()->RegisterPrimary( tc_primary );
     }
   }
 

--- a/G4SOLAr/src/SLArPrimaryGeneratorAction.cc
+++ b/G4SOLAr/src/SLArPrimaryGeneratorAction.cc
@@ -306,8 +306,8 @@ void SLArPrimaryGeneratorAction::GeneratePrimaries(G4Event* anEvent)
 
   printf("Primary Generator Action produced %i vertex(ices)\n", n); 
   for (int i=0; i<n; i++) {
-    //std::unique_ptr<SLArMCPrimaryInfoUniquePtr> tc_primary = std::make_unique<SLArMCPrimaryInfoUniquePtr>();
-    SLArMCPrimaryInfoPtr* tc_primary = new SLArMCPrimaryInfoPtr();
+    std::unique_ptr<SLArMCPrimaryInfoUniquePtr> tc_primary = std::make_unique<SLArMCPrimaryInfoUniquePtr>();
+    //SLArMCPrimaryInfoPtr* tc_primary = new SLArMCPrimaryInfoPtr();
     G4int np = anEvent->GetPrimaryVertex(i)->GetNumberOfParticle(); 
     //printf("vertex %i has %i particles at t = %g\n", n, np, 
         //anEvent->GetPrimaryVertex(i)->GetT0()); 

--- a/G4SOLAr/src/SLArRunAction.cc
+++ b/G4SOLAr/src/SLArRunAction.cc
@@ -47,9 +47,6 @@ void SLArRunAction::BeginOfRunAction(const G4Run* aRun)
   //G4RunManager::GetRunManager()->SetRandomNumberStore(true);
   SLArAnalysisManager* SLArAnaMgr = SLArAnalysisManager::Instance(); 
 
-  // setup backtracker size
-  SLArAnaMgr->SetupBacktrackerRecords(); 
-
   SLArAnaMgr->CreateFileStructure();
 
   fElectronDrift = new SLArElectronDrift(); 

--- a/G4SOLAr/src/SLArStackingAction.cc
+++ b/G4SOLAr/src/SLArStackingAction.cc
@@ -100,8 +100,8 @@ SLArStackingAction::ClassifyNewTrack(const G4Track * aTrack)
       }
       
       //printf("creating trajectory...\n");
-      //std::unique_ptr<SLArEventTrajectory> trajectory = std::make_unique<SLArEventTrajectory>();
-      SLArEventTrajectory* trajectory = new SLArEventTrajectory();
+      std::unique_ptr<SLArEventTrajectory> trajectory = std::make_unique<SLArEventTrajectory>();
+      //SLArEventTrajectory* trajectory = new SLArEventTrajectory();
       trajectory->SetTrackID( aTrack->GetTrackID() ); 
       trajectory->SetParentID(aTrack->GetParentID()); 
       trajectory->SetParticleName( particleName );
@@ -120,11 +120,11 @@ SLArStackingAction::ClassifyNewTrack(const G4Track * aTrack)
       //printf("found\n");
 
       //SLArMCPrimaryInfoUniquePtr* ancestor = nullptr; 
-      SLArMCPrimaryInfoPtr* ancestor = nullptr; 
+      SLArMCPrimaryInfoUniquePtr* ancestor = nullptr; 
       auto& primaries = SLArAnaMgr->GetEvent()->GetPrimaries();
       for (auto &p : primaries) {
         if (p->GetTrackID() == ancestor_id) {
-          ancestor = p; 
+          ancestor = p.get(); 
           break;
         }
       }
@@ -135,7 +135,7 @@ SLArStackingAction::ClassifyNewTrack(const G4Track * aTrack)
 
       ancestor->RegisterTrajectory( std::move(trajectory) ); 
 
-      auto trkInfo = new SLArUserTrackInformation( ancestor->GetTrajectories().back() ); 
+      auto trkInfo = new SLArUserTrackInformation( ancestor->GetTrajectories().back().get() ); 
 
       trkInfo->SetStoreTrajectory(true); 
 
@@ -147,8 +147,8 @@ SLArStackingAction::ClassifyNewTrack(const G4Track * aTrack)
     if(aTrack->GetParentID()>0)
     { // particle is secondary
       SLArAnalysisManager* anaMngr = SLArAnalysisManager::Instance(); 
-      //SLArMCPrimaryInfoUniquePtr* primary = nullptr; 
-      SLArMCPrimaryInfoPtr* primary = nullptr; 
+      SLArMCPrimaryInfoUniquePtr* primary = nullptr; 
+      //SLArMCPrimaryInfoPtr* primary = nullptr; 
       auto& primaries = anaMngr->GetEvent()->GetPrimaries();
 
       int primary_parent_id = fEventAction->FindAncestorID(aTrack->GetParentID()); 
@@ -157,7 +157,7 @@ SLArStackingAction::ClassifyNewTrack(const G4Track * aTrack)
 //#endif
       for (auto &p : primaries) {
         if (p->GetTrackID() == primary_parent_id) {
-          primary = p; 
+          primary = p.get(); 
 //#ifdef SLAR_DEBUG
           //printf("primary parent found\n");
 //#endif

--- a/G4SOLAr/src/SLArStackingAction.cc
+++ b/G4SOLAr/src/SLArStackingAction.cc
@@ -43,6 +43,7 @@
 #include "G4ParticleTypes.hh"
 #include "G4Track.hh"
 #include "G4ios.hh"
+#include <vector>
 
 //....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
 
@@ -60,28 +61,34 @@ SLArStackingAction::~SLArStackingAction()
 G4ClassificationOfNewTrack
 SLArStackingAction::ClassifyNewTrack(const G4Track * aTrack)
 {
-
   G4ClassificationOfNewTrack kClassification = fUrgent; 
 
   if(aTrack->GetDefinition() != G4OpticalPhoton::OpticalPhotonDefinition()) {
     // check it the track already owns a user info 
-    if (aTrack->GetUserInformation()) return kClassification; 
+    if (aTrack->GetUserInformation()) {
+      //printf("Track ID %i already has User Information\n", aTrack->GetTrackID());
+      return kClassification;
+    }
     else {
+      //printf("Track ID %i is a new one!\n", aTrack->GetTrackID());
       auto SLArAnaMgr = SLArAnalysisManager::Instance(); 
       G4int parentID = 0; 
       if (aTrack->GetParentID() == 0) { // this is a primary
         fEventAction->RegisterNewTrackPID(aTrack->GetTrackID(), aTrack->GetTrackID()); 
         parentID = aTrack->GetTrackID(); 
         // fix track ID in primary output object
-        for (auto &primaryInfo : SLArAnaMgr->GetEvent()->GetPrimaries()) {
+        auto& primaries = SLArAnaMgr->GetEvent()->GetPrimaries();
+        for (auto &primaryInfo : primaries) {
           if (fabs(aTrack->GetMomentum().x() - primaryInfo->GetMomentum()[0]) < 1e-6 &&
               fabs(aTrack->GetMomentum().y() - primaryInfo->GetMomentum()[1]) < 1e-6 &&
               fabs(aTrack->GetMomentum().z() - primaryInfo->GetMomentum()[2]) < 1e-6) {
+            //printf("This is a primary: Corrsponding primary info found (%i)\n", primaryInfo.GetTrackID());
             primaryInfo->SetTrackID(aTrack->GetTrackID()); 
             break;
           }
         }
       } else {
+        //printf("Not a primary, recording parent id\n");
         fEventAction->RegisterNewTrackPID(aTrack->GetTrackID(), aTrack->GetParentID()); 
         parentID = aTrack->GetParentID(); 
       }
@@ -92,8 +99,9 @@ SLArStackingAction::ClassifyNewTrack(const G4Track * aTrack)
         creatorProc = aTrack->GetCreatorProcess()->GetProcessName(); 
       }
       
-      auto trkInfo = new SLArUserTrackInformation(); 
-      SLArEventTrajectory* trajectory = new SLArEventTrajectory(); 
+      //printf("creating trajectory...\n");
+      //std::unique_ptr<SLArEventTrajectory> trajectory = std::make_unique<SLArEventTrajectory>();
+      SLArEventTrajectory* trajectory = new SLArEventTrajectory();
       trajectory->SetTrackID( aTrack->GetTrackID() ); 
       trajectory->SetParentID(aTrack->GetParentID()); 
       trajectory->SetParticleName( particleName );
@@ -107,13 +115,17 @@ SLArStackingAction::ClassifyNewTrack(const G4Track * aTrack)
       auto vertex_momentum = aTrack->GetMomentumDirection();
       trajectory->SetInitMomentum( TVector3(
             vertex_momentum.x(), vertex_momentum.y(), vertex_momentum.z() ) );
-
+      //printf("Looking for ancestor...\n");
       G4int ancestor_id = fEventAction->FindAncestorID( parentID ); 
+      //printf("found\n");
 
-      SLArMCPrimaryInfo* ancestor = nullptr; 
-      for (auto &p : SLArAnaMgr->GetEvent()->GetPrimaries()) {
+      //SLArMCPrimaryInfoUniquePtr* ancestor = nullptr; 
+      SLArMCPrimaryInfoPtr* ancestor = nullptr; 
+      auto& primaries = SLArAnaMgr->GetEvent()->GetPrimaries();
+      for (auto &p : primaries) {
         if (p->GetTrackID() == ancestor_id) {
           ancestor = p; 
+          break;
         }
       }
 
@@ -121,11 +133,11 @@ SLArStackingAction::ClassifyNewTrack(const G4Track * aTrack)
       if (!ancestor) printf("Unable to find corresponding primary particle\n");
 #endif
 
-      ancestor->RegisterTrajectory(trajectory); 
+      ancestor->RegisterTrajectory( std::move(trajectory) ); 
+
+      auto trkInfo = new SLArUserTrackInformation( ancestor->GetTrajectories().back() ); 
 
       trkInfo->SetStoreTrajectory(true); 
-
-      trkInfo->SetTrajectory( trajectory ); 
 
       aTrack->SetUserInformation( trkInfo ); 
     }
@@ -135,8 +147,9 @@ SLArStackingAction::ClassifyNewTrack(const G4Track * aTrack)
     if(aTrack->GetParentID()>0)
     { // particle is secondary
       SLArAnalysisManager* anaMngr = SLArAnalysisManager::Instance(); 
-      SLArMCPrimaryInfo* primary = nullptr; 
-      auto primaries = anaMngr->GetEvent()->GetPrimaries();
+      //SLArMCPrimaryInfoUniquePtr* primary = nullptr; 
+      SLArMCPrimaryInfoPtr* primary = nullptr; 
+      auto& primaries = anaMngr->GetEvent()->GetPrimaries();
 
       int primary_parent_id = fEventAction->FindAncestorID(aTrack->GetParentID()); 
 //#ifdef SLAR_DEBUG

--- a/G4SOLAr/src/SLArStackingAction.cc
+++ b/G4SOLAr/src/SLArStackingAction.cc
@@ -79,11 +79,11 @@ SLArStackingAction::ClassifyNewTrack(const G4Track * aTrack)
         // fix track ID in primary output object
         auto& primaries = SLArAnaMgr->GetEvent()->GetPrimaries();
         for (auto &primaryInfo : primaries) {
-          if (fabs(aTrack->GetMomentum().x() - primaryInfo->GetMomentum()[0]) < 1e-6 &&
-              fabs(aTrack->GetMomentum().y() - primaryInfo->GetMomentum()[1]) < 1e-6 &&
-              fabs(aTrack->GetMomentum().z() - primaryInfo->GetMomentum()[2]) < 1e-6) {
+          if (fabs(aTrack->GetMomentum().x() - primaryInfo.GetMomentum()[0]) < 1e-6 &&
+              fabs(aTrack->GetMomentum().y() - primaryInfo.GetMomentum()[1]) < 1e-6 &&
+              fabs(aTrack->GetMomentum().z() - primaryInfo.GetMomentum()[2]) < 1e-6) {
             //printf("This is a primary: Corrsponding primary info found (%i)\n", primaryInfo.GetTrackID());
-            primaryInfo->SetTrackID(aTrack->GetTrackID()); 
+            primaryInfo.SetTrackID(aTrack->GetTrackID()); 
             break;
           }
         }
@@ -123,8 +123,8 @@ SLArStackingAction::ClassifyNewTrack(const G4Track * aTrack)
       SLArMCPrimaryInfo* ancestor = nullptr; 
       auto& primaries = SLArAnaMgr->GetEvent()->GetPrimaries();
       for (auto &p : primaries) {
-        if (p->GetTrackID() == ancestor_id) {
-          ancestor = p; 
+        if (p.GetTrackID() == ancestor_id) {
+          ancestor = &p; 
           break;
         }
       }
@@ -156,8 +156,8 @@ SLArStackingAction::ClassifyNewTrack(const G4Track * aTrack)
       //printf("Primary parent ID %i\n", primary_parent_id);
 //#endif
       for (auto &p : primaries) {
-        if (p->GetTrackID() == primary_parent_id) {
-          primary = p; 
+        if (p.GetTrackID() == primary_parent_id) {
+          primary = &p; 
 //#ifdef SLAR_DEBUG
           //printf("primary parent found\n");
 //#endif

--- a/G4SOLAr/src/SLArStackingAction.cc
+++ b/G4SOLAr/src/SLArStackingAction.cc
@@ -101,7 +101,7 @@ SLArStackingAction::ClassifyNewTrack(const G4Track * aTrack)
       
       //printf("creating trajectory...\n");
       std::unique_ptr<SLArEventTrajectory> trajectory = std::make_unique<SLArEventTrajectory>();
-      //SLArEventTrajectory* trajectory = new SLArEventTrajectory();
+      //SLArEventTrajectory trajectory;
       trajectory->SetTrackID( aTrack->GetTrackID() ); 
       trajectory->SetParentID(aTrack->GetParentID()); 
       trajectory->SetParticleName( particleName );
@@ -120,11 +120,11 @@ SLArStackingAction::ClassifyNewTrack(const G4Track * aTrack)
       //printf("found\n");
 
       //SLArMCPrimaryInfoUniquePtr* ancestor = nullptr; 
-      SLArMCPrimaryInfoUniquePtr* ancestor = nullptr; 
+      SLArMCPrimaryInfo* ancestor = nullptr; 
       auto& primaries = SLArAnaMgr->GetEvent()->GetPrimaries();
       for (auto &p : primaries) {
         if (p->GetTrackID() == ancestor_id) {
-          ancestor = p.get(); 
+          ancestor = p; 
           break;
         }
       }
@@ -147,7 +147,7 @@ SLArStackingAction::ClassifyNewTrack(const G4Track * aTrack)
     if(aTrack->GetParentID()>0)
     { // particle is secondary
       SLArAnalysisManager* anaMngr = SLArAnalysisManager::Instance(); 
-      SLArMCPrimaryInfoUniquePtr* primary = nullptr; 
+      SLArMCPrimaryInfo* primary = nullptr; 
       //SLArMCPrimaryInfoPtr* primary = nullptr; 
       auto& primaries = anaMngr->GetEvent()->GetPrimaries();
 
@@ -157,7 +157,7 @@ SLArStackingAction::ClassifyNewTrack(const G4Track * aTrack)
 //#endif
       for (auto &p : primaries) {
         if (p->GetTrackID() == primary_parent_id) {
-          primary = p.get(); 
+          primary = p; 
 //#ifdef SLAR_DEBUG
           //printf("primary parent found\n");
 //#endif

--- a/G4SOLAr/src/SLArStackingAction.cc
+++ b/G4SOLAr/src/SLArStackingAction.cc
@@ -109,6 +109,7 @@ SLArStackingAction::ClassifyNewTrack(const G4Track * aTrack)
       trajectory->SetCreatorProcess( creatorProc ); 
       trajectory->SetTime( aTrack->GetGlobalTime() ); 
       trajectory->SetWeight(aTrack->GetWeight()); 
+      trajectory->SetStoreTrajectoryPts( SLArAnaMgr->StoreTrajectoryFull() ); 
       
 
       trajectory->SetInitKineticEne( aTrack->GetKineticEnergy() ); 

--- a/G4SOLAr/src/SLArSteppingAction.cc
+++ b/G4SOLAr/src/SLArSteppingAction.cc
@@ -59,9 +59,10 @@ void SLArSteppingAction::UserSteppingAction(const G4Step* step)
   if (!thePostPV) thePostPV = thePrePV;
 
 //#ifdef SLAR_DEBUG
-  //printf("Particle: %s at [%.0f , %0.f, %0.f]- Boundary check: %s (%s) | %s (%s)\n", 
+  //printf("Particle: %s at [%.0f , %0.f, %0.f] - trkID %i- Boundary check: %s (%s) | %s (%s)\n", 
       //particleDef->GetParticleName().data(),
       //thePrePoint->GetPosition().x(), thePrePoint->GetPosition().y(), thePrePoint->GetPosition().z(), 
+      //track->GetTrackID(),
       //thePrePV->GetName().c_str(), 
       //thePrePV->GetLogicalVolume()->GetMaterial()->GetName().c_str(), 
       //thePostPV->GetName().c_str(), 
@@ -72,7 +73,7 @@ void SLArSteppingAction::UserSteppingAction(const G4Step* step)
   
   if (track->GetParticleDefinition() != G4OpticalPhoton::OpticalPhotonDefinition()) {
     auto trkInfo = (SLArUserTrackInformation*)track->GetUserInformation(); 
-    auto trajectory = trkInfo->GimmeEvTrajectory();
+    SLArEventTrajectory* trajectory = trkInfo->GimmeEvTrajectory();
     double edep = step->GetTotalEnergyDeposit();
     auto stepMngr = fTrackinAction->GetTrackingManager()->GetSteppingManager(); 
     int n_ph = 0; 
@@ -96,7 +97,10 @@ void SLArSteppingAction::UserSteppingAction(const G4Step* step)
 
     if (trkInfo->CheckStoreTrajectory() == true) {
       trj_point step_point; 
-      if (trkInfo->GimmeEvTrajectory()->GetPoints().empty()) {
+
+      //printf("SLArSteppingAction::here we go\n"); 
+      //printf("trajectory has %lu points\n", trajectory->GetPoints().size());
+      if (trajectory->GetPoints().empty()) {
         // record origin point
         const auto pos = thePrePoint->GetPosition(); 
         step_point.fX = pos.x(); 
@@ -138,13 +142,14 @@ void SLArSteppingAction::UserSteppingAction(const G4Step* step)
     //printf("SLArSteppingAction::UserSteppingAction: adding %i ph and %i e ion. to %s [%i]\n", 
         //n_ph, n_el, 
         //particleDef->GetParticleName().c_str(), track->GetTrackID());
-    //getchar(); 
     //printf("trk ID %i [%i], PDG ID %i [%i] - trj size %lu\n", 
         //track->GetTrackID(), 
-        //trajectory->GetTrackID(), 
+        //trajectory.GetTrackID(), 
         //track->GetParticleDefinition()->GetPDGEncoding(),
-        //trajectory->GetPDGID(), 
-        //trajectory->GetPoints().size());
+        //trajectory.GetPDGID(), 
+        //trajectory.GetPoints().size());
+    //getchar(); 
+
     if (track->GetTrackStatus() == fStopAndKill) {
 
       auto process = 
@@ -158,7 +163,7 @@ void SLArSteppingAction::UserSteppingAction(const G4Step* step)
         target = hproc->GetTargetIsotope();
         G4String targetName = "XXXX";  
         if (target) targetName = target->GetName();
-        nuclearChannel += " + " + targetName + " --> ";
+        nuclearChannel += " + " + targetName + " -> ";
 
         std::map<G4ParticleDefinition*, G4int> particle_counter;
         const std::vector<const G4Track*>* secondary 
@@ -194,7 +199,6 @@ void SLArSteppingAction::UserSteppingAction(const G4Step* step)
 
       }
 
-
       trkInfo->GimmeEvTrajectory()->SetEndProcess(terminator); 
     }
   }
@@ -220,10 +224,10 @@ void SLArSteppingAction::UserSteppingAction(const G4Step* step)
       for( i=0;i<nprocesses;i++){
         if((*pv)[i]->GetProcessName()=="OpBoundary"){
           boundary = (G4OpBoundaryProcess*)(*pv)[i];
-#ifdef SLAR_DEBUG
-          G4cout<< "Optical ph at " << thePrePV->GetName() 
-            << "/" << thePostPV->GetName() << " boundary!" << G4endl; 
-#endif
+//#ifdef SLAR_DEBUG
+          //G4cout<< "Optical ph at " << thePrePV->GetName() 
+            //<< "/" << thePostPV->GetName() << " boundary!" << G4endl; 
+//#endif
           break;
         }
       }
@@ -302,7 +306,7 @@ void SLArSteppingAction::UserSteppingAction(const G4Step* step)
 #ifdef SLAR_DEBUG
              printf("Detection in %s - copy id [%i]\n", 
                  volName.c_str(), touchable->GetCopyNumber(0)); 
-             getchar(); 
+             //getchar(); 
 #endif
 
             phInfo->AddTrackStatusFlag(hitPMT);
@@ -345,7 +349,7 @@ void SLArSteppingAction::UserSteppingAction(const G4Step* step)
                   touchable->GetCopyNumber(3),
                   touchable->GetCopyNumber(4)
                   );
-              getchar(); 
+              //getchar(); 
 #endif
 
               supercellSD = (SLArSuperCellSD*)SDman->FindSensitiveDetector(sdNameSC);

--- a/G4SOLAr/src/SLArSteppingAction.cc
+++ b/G4SOLAr/src/SLArSteppingAction.cc
@@ -96,43 +96,45 @@ void SLArSteppingAction::UserSteppingAction(const G4Step* step)
     }
 
     if (trkInfo->CheckStoreTrajectory() == true) {
-      trj_point step_point; 
+      if (trajectory->DoStoreTrajectoryPts()) {
+        trj_point step_point; 
 
-      //printf("SLArSteppingAction::here we go\n"); 
-      //printf("trajectory has %lu points\n", trajectory->GetPoints().size());
-      if (trajectory->GetPoints().empty()) {
-        // record origin point
-        const auto pos = thePrePoint->GetPosition(); 
+        //printf("SLArSteppingAction::here we go\n"); 
+        //printf("trajectory has %lu points\n", trajectory->GetPoints().size());
+        if (trajectory->GetPoints().empty()) {
+          // record origin point
+          const auto pos = thePrePoint->GetPosition(); 
+          step_point.fX = pos.x(); 
+          step_point.fY = pos.y(); 
+          step_point.fZ = pos.z(); 
+          step_point.fKEnergy = thePrePoint->GetKineticEnergy(); 
+          step_point.fEdep = 0.; 
+          step_point.fCopy = thePrePV->GetCopyNo(); 
+          const auto material_name = 
+            thePostPV->GetLogicalVolume()->GetMaterial()->GetName();
+          if ( G4StrUtil::contains(material_name, "LAr") ) {
+            step_point.fLAr = true;
+          }
+          step_point.fNel = 0.;
+          step_point.fNph = 0.; 
+          trajectory->RegisterPoint(step_point); 
+        }
+        const auto pos = step->GetPostStepPoint()->GetPosition(); 
         step_point.fX = pos.x(); 
         step_point.fY = pos.y(); 
         step_point.fZ = pos.z(); 
-        step_point.fKEnergy = thePrePoint->GetKineticEnergy(); 
-        step_point.fEdep = 0.; 
-        step_point.fCopy = thePrePV->GetCopyNo(); 
+        step_point.fKEnergy = thePostPoint->GetKineticEnergy(); 
+        step_point.fEdep = edep; 
+        step_point.fCopy = thePostPV->GetCopyNo(); 
         const auto material_name = 
           thePostPV->GetLogicalVolume()->GetMaterial()->GetName();
         if ( G4StrUtil::contains(material_name, "LAr") ) {
           step_point.fLAr = true;
         }
-        step_point.fNel = 0.;
-        step_point.fNph = 0.; 
+        step_point.fNel = n_el;
+        step_point.fNph = n_ph; 
         trajectory->RegisterPoint(step_point); 
       }
-      const auto pos = step->GetPostStepPoint()->GetPosition(); 
-      step_point.fX = pos.x(); 
-      step_point.fY = pos.y(); 
-      step_point.fZ = pos.z(); 
-      step_point.fKEnergy = thePostPoint->GetKineticEnergy(); 
-      step_point.fEdep = edep; 
-      step_point.fCopy = thePostPV->GetCopyNo(); 
-      const auto material_name = 
-        thePostPV->GetLogicalVolume()->GetMaterial()->GetName();
-      if ( G4StrUtil::contains(material_name, "LAr") ) {
-        step_point.fLAr = true;
-      }
-      step_point.fNel = n_el;
-      step_point.fNph = n_ph; 
-      trajectory->RegisterPoint(step_point); 
     }
 
     trajectory->IncrementEdep( edep ); 

--- a/G4SOLAr/src/SLArTrackingAction.cc
+++ b/G4SOLAr/src/SLArTrackingAction.cc
@@ -9,6 +9,7 @@
 #include "SLArTrajectory.hh"
 #include "SLArTrackingAction.hh"
 #include "SLArUserPhotonTrackInformation.hh"
+#include "SLArUserTrackInformation.hh"
 #include "SLArDetectorConstruction.hh"
 
 #include "G4TrackingManager.hh"
@@ -16,6 +17,7 @@
 #include "G4ParticleTypes.hh"
 #include "G4EventManager.hh"
 #include "G4Event.hh"
+#include <cstdio>
 
 //....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
 
@@ -27,20 +29,54 @@ SLArTrackingAction::~SLArTrackingAction() {}
 
 void SLArTrackingAction::PreUserTrackingAction(const G4Track* aTrack)
 {
+#ifdef SLAR_DEBUG
+  printf("SLArTrackingAction::PreUserTrackingAction\n");
+#endif // DEBUG
 
   //Let this be up to the user via vis.mac
   if (aTrack->GetParticleDefinition() != G4OpticalPhoton::OpticalPhotonDefinition())
   {
-    //fpTrackingManager->SetStoreTrajectory(true);
+    fpTrackingManager->SetStoreTrajectory(true);
+    auto trkInfo = (SLArUserTrackInformation*)aTrack->GetUserInformation();
+
+    if (trkInfo) {
+      if (trkInfo->GimmeEvTrajectory()->GetConstPoints().empty()) {
+        fpTrackingManager->SetTrajectory(new SLArTrajectory(aTrack));
+      }
+      else {
+        auto event = G4EventManager::GetEventManager()->GetNonconstCurrentEvent();
+        auto trj_container = event->GetTrajectoryContainer();
+
+        if (trj_container) {
+          auto trj_vector = trj_container->GetVector();
+          for (auto &tt : *trj_vector) {
+            auto t = (SLArTrajectory*)tt;
+            if (t->GetTrackID() == aTrack->GetTrackID()) {
+              fpTrackingManager->SetTrajectory( t );
+              break;
+            }
+          }
+        }
+      }
+    }
+
   }
   else {
-    //fpTrackingManager->SetStoreTrajectory(true);
-    //This user track information is only relevant to the photons
-    fpTrackingManager->SetUserTrackInformation(
-        new SLArUserPhotonTrackInformation);
+    if (fpTrackingManager->GetStoreTrajectory()) {
+      fpTrackingManager->SetStoreTrajectory(true);
+      //This user track information is only relevant to the photons
+      fpTrackingManager->SetUserTrackInformation(
+          new SLArUserPhotonTrackInformation);
+      if (fpTrackingManager->GetStoreTrajectory()) {
+        fpTrackingManager->SetTrajectory(new SLArTrajectory(aTrack));
+      }
+    }
   }
-  //Use custom trajectory class
-  fpTrackingManager->SetTrajectory(new SLArTrajectory(aTrack));
+
+#ifdef SLAR_DEBUG
+  printf("SLArTrackingAction::PreUserTrackingAction() DONE\n");
+#endif // DEBUG
+       //Use custom trajectory class
 }
 
 //....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
@@ -51,33 +87,34 @@ void SLArTrackingAction::PostUserTrackingAction(const G4Track* aTrack){
     (SLArTrajectory*)fpTrackingManager->GimmeTrajectory();
 
   //Lets choose to draw only the photons that hit the sphere and a pmt
-  if(aTrack->GetDefinition()==
-      G4OpticalPhoton::OpticalPhotonDefinition()){
-    SLArUserPhotonTrackInformation*
-      trackInformation=(SLArUserPhotonTrackInformation*)aTrack->GetUserInformation();
+  if (fpTrackingManager->GetStoreTrajectory()) {
+    if(aTrack->GetDefinition()==
+        G4OpticalPhoton::OpticalPhotonDefinition()){
+      SLArUserPhotonTrackInformation*
+        trackInformation=(SLArUserPhotonTrackInformation*)aTrack->GetUserInformation();
 
-    /*
-     *const G4VProcess* creator=aTrack->GetCreatorProcess();
-     *if(creator && creator->GetProcessName()=="OpWLS"){
-     *  trajectory->WLS();
-     *  trajectory->SetDrawTrajectory(true);
-     *}
-     */
+      /*
+       *const G4VProcess* creator=aTrack->GetCreatorProcess();
+       *if(creator && creator->GetProcessName()=="OpWLS"){
+       *  trajectory->WLS();
+       *  trajectory->SetDrawTrajectory(true);
+       *}
+       */
 
-    //if((trackInformation->GetTrackStatus()&hitPMT)|| 
-       //(trackInformation->GetTrackStatus()&absorbed) ||
-       //(trackInformation->GetTrackStatus()&boundaryAbsorbed) )
-    trajectory->SetDrawTrajectory(true);
+      //if((trackInformation->GetTrackStatus()&hitPMT)|| 
+      //(trackInformation->GetTrackStatus()&absorbed) ||
+      //(trackInformation->GetTrackStatus()&boundaryAbsorbed) )
+      trajectory->SetDrawTrajectory(true);
 
-    if (trackInformation) {
-      if(trackInformation->GetForceDrawTrajectory())
-        trajectory->SetDrawTrajectory(true);
+      if (trackInformation) {
+        if(trackInformation->GetForceDrawTrajectory())
+          trajectory->SetDrawTrajectory(true);
+      }
     }
+    else //draw all other trajectories and store them in SLArMCPrimaryInfo
+    {
+      trajectory->SetDrawTrajectory(true);
+    }  
   }
-  else //draw all other trajectories and store them in SLArMCPrimaryInfo
-  {
-    trajectory->SetDrawTrajectory(true);
-  }  
-
 
 }

--- a/G4SOLAr/src/SLArTrajectory.cc
+++ b/G4SOLAr/src/SLArTrajectory.cc
@@ -44,6 +44,7 @@ SLArTrajectory::SLArTrajectory(const G4Track* aTrack)
       G4OpticalPhoton::Definition()) {
     printf("SLArTrajectory: Create new SLArTrajectory for trk %i\n", 
         aTrack->GetTrackID());
+    getchar();
   }
 #endif
 
@@ -57,16 +58,17 @@ SLArTrajectory::SLArTrajectory(const G4Track* aTrack)
     fCreatorProcess    =aTrack->GetCreatorProcess()->GetProcessName();
   }
   else {
+    fCreatorProcess = "PrimaryGenerator";
     // this is a primary. Save the track ID in the corresponding SLArMCPrimaryInfo
-    SLArAnalysisManager* SLArAnaMgr = SLArAnalysisManager::Instance();
-    for (auto &primaryInfo : SLArAnaMgr->GetEvent()->GetPrimaries()) {
-      if (fabs(aTrack->GetMomentum().x() - primaryInfo->GetMomentum()[0]) < 1e-6 &&
-          fabs(aTrack->GetMomentum().y() - primaryInfo->GetMomentum()[1]) < 1e-6 &&
-          fabs(aTrack->GetMomentum().z() - primaryInfo->GetMomentum()[2]) < 1e-6) {
-        primaryInfo->SetTrackID(aTrack->GetTrackID()); 
-        break;
-      }
-    }
+    //SLArAnalysisManager* SLArAnaMgr = SLArAnalysisManager::Instance();
+    //for (auto &primaryInfo : SLArAnaMgr->GetEvent()->GetPrimaries()) {
+      //if (fabs(aTrack->GetMomentum().x() - primaryInfo.GetMomentum()[0]) < 1e-6 &&
+          //fabs(aTrack->GetMomentum().y() - primaryInfo.GetMomentum()[1]) < 1e-6 &&
+          //fabs(aTrack->GetMomentum().z() - primaryInfo.GetMomentum()[2]) < 1e-6) {
+        //primaryInfo.SetTrackID(aTrack->GetTrackID()); 
+        //break;
+      //}
+    //}
   }
   fTime = aTrack->GetGlobalTime(); 
 }

--- a/G4SOLAr/src/SLArUserTrackInformation.cc
+++ b/G4SOLAr/src/SLArUserTrackInformation.cc
@@ -6,18 +6,17 @@
 
 #include "SLArUserTrackInformation.hh"
 
-SLArUserTrackInformation::SLArUserTrackInformation()
-  : G4VUserTrackInformation(), fTrajectory(nullptr), fStoreTrajectory(0)
+SLArUserTrackInformation::SLArUserTrackInformation(SLArEventTrajectory* trj)
+  : G4VUserTrackInformation(), fTrajectory(trj), fStoreTrajectory(0)
 {}
 
-SLArUserTrackInformation::SLArUserTrackInformation(const G4String& infoType) 
-  : G4VUserTrackInformation(infoType), fTrajectory(nullptr), fStoreTrajectory(0)
+SLArUserTrackInformation::SLArUserTrackInformation(SLArEventTrajectory* trj, const G4String& infoType) 
+  : G4VUserTrackInformation(infoType), fTrajectory(trj), fStoreTrajectory(0)
 {}
 
 SLArUserTrackInformation::SLArUserTrackInformation(const SLArUserTrackInformation& info)
-  : G4VUserTrackInformation(info) 
+  : G4VUserTrackInformation(info), fTrajectory(info.fTrajectory)
 {
-  fTrajectory = info.fTrajectory; 
   fStoreTrajectory = info.fStoreTrajectory; 
 }
 

--- a/G4SOLAr/src/config/SLArCfgAnode.cc
+++ b/G4SOLAr/src/config/SLArCfgAnode.cc
@@ -28,7 +28,7 @@ SLArCfgAnode::~SLArCfgAnode() {
   fAnodeLevelsMap.clear(); 
 }
 
-SLArCfgAnode::SLArPixIdxCoord SLArCfgAnode::FindPixel(double x0, double x1) {
+SLArCfgAnode::SLArPixIdxCoord SLArCfgAnode::GetPixelBinCoord(const double& x0, const double& x1) {
   SLArCfgAnode::SLArPixIdxCoord pidx = {-9}; 
 
   int ibin = fAnodeLevelsMap[0]->FindBin(x0, x1); 
@@ -72,6 +72,51 @@ SLArCfgAnode::SLArPixIdxCoord SLArCfgAnode::FindPixel(double x0, double x1) {
   return pidx; 
 }
 
+SLArCfgAnode::SLArPixIdxCoord SLArCfgAnode::GetPixelCoord(const double& x0, const double& x1) {
+  SLArCfgAnode::SLArPixIdxCoord pidx = {-9}; 
+
+  int ibin = fAnodeLevelsMap[0]->FindBin(x0, x1); 
+
+  SLArCfgMegaTile* megatile = FindBaseElementInMap(ibin);
+  if (megatile) {
+    TVector3 mt_pos = TVector3(megatile->GetPhysX(), megatile->GetPhysY(), megatile->GetPhysZ()); 
+    //printf("megatile_pos: [%g, %g, %g] mm\n", 
+    //mt_pos[0], mt_pos[1], mt_pos[2]); 
+ 
+    pidx[0] = megatile->GetIdx();  
+    Double_t mt_x0 = mt_pos.Dot(fAxis0); 
+    Double_t mt_x1 = mt_pos.Dot(fAxis1); 
+    //printf("correct for MT %s coordinates: %g, %g mm -> %g, %g \n", 
+        //megatile->GetName(), mt_x0, mt_x1, x0-mt_x0, x1-mt_x1);
+    ibin = fAnodeLevelsMap[1]->FindBin(x0-mt_x0, x1-mt_x1);
+    SLArCfgReadoutTile* tile = megatile->FindBaseElementInMap(ibin); 
+    if (tile) {
+      pidx[1] = tile->GetIdx(); 
+      TVector3 tile_pos(tile->GetPhysX(), tile->GetPhysY(), tile->GetPhysZ()); 
+      //printf("tile_pos: [%g, %g, %g]\n", tile_pos[0], tile_pos[1], tile_pos[2]);
+      Double_t t_x0 = tile_pos.Dot(fAxis0);
+      Double_t t_x1 = tile_pos.Dot(fAxis1); 
+      pidx[2] = fAnodeLevelsMap[2]->FindBin(x0-t_x0, x1-t_x1); 
+      //printf("pix id %i\n", pidx[2]);
+    } 
+#ifdef SLAR_DEBUG
+    else {
+      printf("Cannot find tile with bin index %i\n", ibin);
+    }
+#endif
+
+  } 
+#ifdef SLAR_DEBUG
+  else {
+    printf("SLArCfgAnode::FindPixel(%g, %g)\n", x0, x1);
+    printf("Coordinates outside of anode scope\n"); 
+  }
+#endif
+
+  return pidx; 
+}
+
+
 void SLArCfgAnode::RegisterMap(size_t ilevel, TH2Poly* hmap) {
   if (fAnodeLevelsMap.count(ilevel)) {
     printf("SLArCfgAnode::RegisterMap(%lu) ERROR\n", ilevel); 
@@ -97,7 +142,9 @@ TH2Poly* SLArCfgAnode::ConstructPixHistMap(const int depth,
     case 1:
       {
         SLArCfgMegaTile* cfgMegaTile  = GetBaseElement(idx[0]); 
-        if (!cfgMegaTile) return nullptr; 
+        if (!cfgMegaTile) {
+          return nullptr;
+        }
         return cfgMegaTile->BuildPolyBinHist(); 
       }
       break;
@@ -106,7 +153,11 @@ TH2Poly* SLArCfgAnode::ConstructPixHistMap(const int depth,
     case 2:
       {
         SLArCfgMegaTile* cfgMegaTile  = GetBaseElement(idx[0]); 
-        if (!cfgMegaTile) return nullptr; 
+        if (!cfgMegaTile) {
+          printf("SLArCfgAnode::ConstructPixHistMap ERROR. Cannot find MT %i in configuration\n", 
+              idx[0]);
+          return nullptr; 
+        }
         SLArCfgReadoutTile* cfgTile = cfgMegaTile->GetBaseElement(idx[1]);
         auto tile_pos = 
           TVector3( cfgTile->GetPhysX(), cfgTile->GetPhysY(), cfgTile->GetPhysZ() ); 

--- a/G4SOLAr/src/config/SLArCfgBaseSystem.cc
+++ b/G4SOLAr/src/config/SLArCfgBaseSystem.cc
@@ -120,10 +120,8 @@ TH2Poly* SLArCfgBaseSystem<TAssemblyModule>::BuildPolyBinHist()
     auto g = mod.second->BuildGShape(); 
     TString gBinName = Form("gBin%i", iBin);
     printf("SLArCfgBaseSystem::BuildPolyBinHist: Adding bin %i\n", iBin);
-    int bin_idx = h2Bins->AddBin(
-        g->Clone(gBinName));
+    int bin_idx = h2Bins->AddBin((TGraph*)g.Clone(gBinName));
     mod.second->SetBinIdx(bin_idx);
-    delete g; 
     iBin ++;
   }
 
@@ -160,6 +158,41 @@ TAssemblyModule* SLArCfgBaseSystem<TAssemblyModule>::FindBaseElementInMap(int ib
     //if (mod.second) mod.second->ResetH2Hits(); 
   //}
 //}
+
+template<class TAssemblyModule> 
+TGraph SLArCfgBaseSystem<TAssemblyModule>::BuildGShape() {
+  double x_min =  1e10;
+  double x_max = -1e10; 
+  double y_min =  1e10; 
+  double y_max = -1e10; 
+
+  for (const auto &el : fElementsMap) {
+    TGraph gbin = el.second->BuildGShape(); 
+    double* x = gbin.GetX(); 
+    double* y = gbin.GetY(); 
+    int n = gbin.GetN(); 
+    double x_min_bin = *std::min_element(x, x+n);
+    double x_max_bin = *std::max_element(x, x+n); 
+    double y_min_bin = *std::min_element(y, y+n); 
+    double y_max_bin = *std::max_element(y, y+n); 
+
+    if (x_min_bin < x_min) x_min = x_min_bin; 
+    if (x_max_bin > x_max) x_max = x_max_bin; 
+    if (y_min_bin < y_min) y_min = y_min_bin; 
+    if (y_max_bin > y_max) y_max = y_max_bin;
+  }
+
+  TGraph g(5); 
+  g.SetPoint(0, x_min, y_min); 
+  g.SetPoint(1, x_min, y_max); 
+  g.SetPoint(2, x_max, y_max); 
+  g.SetPoint(3, x_max, y_min); 
+  g.SetPoint(4, x_min, y_min); 
+
+  g.SetName(Form("g%s", fName.Data())); 
+  return g;
+}
+
 
 template class SLArCfgBaseSystem<SLArCfgSuperCellArray>;
 

--- a/G4SOLAr/src/config/SLArCfgReadoutTile.cc
+++ b/G4SOLAr/src/config/SLArCfgReadoutTile.cc
@@ -93,9 +93,9 @@ SLArCfgReadoutTile::~SLArCfgReadoutTile()
  *}
  */
 
-TGraph* SLArCfgReadoutTile::BuildGShape() 
+TGraph SLArCfgReadoutTile::BuildGShape() 
 {
-  TGraph* g = new TGraph(5);
+  TGraph g(5);
   TVector3 pos(fPhysX, fPhysY, fPhysZ); 
   TVector3 size_tmp = fSize; 
   TRotation rot; 
@@ -103,13 +103,13 @@ TGraph* SLArCfgReadoutTile::BuildGShape()
   rot = rot.Inverse(); 
   size_tmp.Transform( rot ); 
   
-  g->SetPoint(0, fAxis0.Dot(pos-0.5*size_tmp), fAxis1.Dot(pos-0.5*size_tmp));
-  g->SetPoint(1, fAxis0.Dot(pos-0.5*size_tmp), fAxis1.Dot(pos+0.5*size_tmp));
-  g->SetPoint(2, fAxis0.Dot(pos+0.5*size_tmp), fAxis1.Dot(pos+0.5*size_tmp));
-  g->SetPoint(3, fAxis0.Dot(pos+0.5*size_tmp), fAxis1.Dot(pos-0.5*size_tmp));
-  g->SetPoint(4, fAxis0.Dot(pos-0.5*size_tmp), fAxis1.Dot(pos-0.5*size_tmp));
+  g.SetPoint(0, fAxis0.Dot(pos-0.5*size_tmp), fAxis1.Dot(pos-0.5*size_tmp));
+  g.SetPoint(1, fAxis0.Dot(pos-0.5*size_tmp), fAxis1.Dot(pos+0.5*size_tmp));
+  g.SetPoint(2, fAxis0.Dot(pos+0.5*size_tmp), fAxis1.Dot(pos+0.5*size_tmp));
+  g.SetPoint(3, fAxis0.Dot(pos+0.5*size_tmp), fAxis1.Dot(pos-0.5*size_tmp));
+  g.SetPoint(4, fAxis0.Dot(pos-0.5*size_tmp), fAxis1.Dot(pos-0.5*size_tmp));
 
-  g->SetName(Form("gShape%i", fIdx)); 
+  g.SetName(Form("gShape%i", fIdx)); 
 
   return g;
 }

--- a/G4SOLAr/src/config/SLArCfgSuperCell.cc
+++ b/G4SOLAr/src/config/SLArCfgSuperCell.cc
@@ -28,9 +28,9 @@ SLArCfgSuperCell::~SLArCfgSuperCell()
   //if (fGShape) {delete fGShape; fGShape = nullptr;}
 }
 
-TGraph* SLArCfgSuperCell::BuildGShape() 
+TGraph SLArCfgSuperCell::BuildGShape() 
 {
-  TGraph* g = new TGraph(5);
+  TGraph g(5);
   TVector3 pos(fPhysX, fPhysY, fPhysZ); 
   TVector3 size_tmp = fSize; 
   TRotation rot; 
@@ -38,11 +38,11 @@ TGraph* SLArCfgSuperCell::BuildGShape()
   rot = rot.Inverse(); 
   size_tmp.Transform( rot ); 
   
-  g->SetPoint(0, fAxis0.Dot(pos-0.5*size_tmp), fAxis1.Dot(pos-0.5*size_tmp));
-  g->SetPoint(1, fAxis0.Dot(pos-0.5*size_tmp), fAxis1.Dot(pos+0.5*size_tmp));
-  g->SetPoint(2, fAxis0.Dot(pos+0.5*size_tmp), fAxis1.Dot(pos+0.5*size_tmp));
-  g->SetPoint(3, fAxis0.Dot(pos+0.5*size_tmp), fAxis1.Dot(pos-0.5*size_tmp));
-  g->SetPoint(4, fAxis0.Dot(pos-0.5*size_tmp), fAxis1.Dot(pos-0.5*size_tmp));
+  g.SetPoint(0, fAxis0.Dot(pos-0.5*size_tmp), fAxis1.Dot(pos-0.5*size_tmp));
+  g.SetPoint(1, fAxis0.Dot(pos-0.5*size_tmp), fAxis1.Dot(pos+0.5*size_tmp));
+  g.SetPoint(2, fAxis0.Dot(pos+0.5*size_tmp), fAxis1.Dot(pos+0.5*size_tmp));
+  g.SetPoint(3, fAxis0.Dot(pos+0.5*size_tmp), fAxis1.Dot(pos-0.5*size_tmp));
+  g.SetPoint(4, fAxis0.Dot(pos-0.5*size_tmp), fAxis1.Dot(pos-0.5*size_tmp));
 
   //printf("gbin:"); 
   //for (int i=0; i<5; i++) {
@@ -57,7 +57,7 @@ TGraph* SLArCfgSuperCell::BuildGShape()
   //g->SetPoint(4, fPhysZ-0.5*f2DSize_X, fPhysY-0.5*f2DSize_Y);
 
 
-  g->SetName(Form("gShape%i", fIdx)); 
+  g.SetName(Form("gShape%i", fIdx)); 
   return g; 
 }
 

--- a/G4SOLAr/src/detector/Anode/SLArReadoutTileSD.cc
+++ b/G4SOLAr/src/detector/Anode/SLArReadoutTileSD.cc
@@ -74,6 +74,14 @@ G4bool SLArReadoutTileSD::ProcessHits_constStep(const G4Step* step,
   if(track->GetDefinition()
      != G4OpticalPhoton::OpticalPhotonDefinition()) return false;
 
+#ifdef SLAR_DEBUG
+  printf("SLArReadoutTileSD::ProcessHits_constStep(): processing %s [%i] TPC hit\n", 
+      step->GetTrack()->GetParticleDefinition()->GetParticleName().data(), 
+      step->GetTrack()->GetTrackID());
+  //getchar(); 
+#endif
+
+
   G4double phEne = 0*CLHEP::eV;
   //G4StepPoint* preStepPoint  = step->GetPreStepPoint();
   G4StepPoint* postStepPoint = step->GetPostStepPoint();
@@ -116,7 +124,7 @@ G4bool SLArReadoutTileSD::ProcessHits_constStep(const G4Step* step,
 #ifdef SLAR_DEBUG
   printf("SLArReadoutTileSD::ProcessHits_constStep\n");
   printf("%s photon hit at t = %g ns\n", procName.c_str(), hit->GetTime());
-  if (hit->GetTime() < 1*CLHEP::ns) getchar(); 
+  //if (hit->GetTime() < 1*CLHEP::ns) getchar(); 
 #endif
   fHitsCollection->insert(hit);
 

--- a/G4SOLAr/src/detector/SuperCell/SLArSuperCellSD.cc
+++ b/G4SOLAr/src/detector/SuperCell/SLArSuperCellSD.cc
@@ -78,6 +78,15 @@ G4bool SLArSuperCellSD::ProcessHits(G4Step* step, G4TouchableHistory*)
 
   G4TouchableHistory* touchable
     = (G4TouchableHistory*)(step->GetPreStepPoint()->GetTouchable());
+
+
+#ifdef SLAR_DEBUG
+  printf("SLArSuperCellSD::ProcessHits(): processing %s [%i] TPC hit\n", 
+      step->GetTrack()->GetParticleDefinition()->GetParticleName().data(), 
+      step->GetTrack()->GetTrackID());
+  //getchar(); 
+#endif
+
   //if (step->GetTrack()->GetDynamicParticle()
       //->GetDefinition()->GetParticleName() != "opticalphoton") {
 
@@ -110,6 +119,13 @@ G4bool SLArSuperCellSD::ProcessHits_constStep(const G4Step* step,
   //need to know if this is an optical photon
   if(track->GetDefinition()
      != G4OpticalPhoton::OpticalPhotonDefinition()) return false;
+#ifdef SLAR_DEBUG
+  printf("SLArSuperCellSD::ProcessHits_constStep(): processing %s [%i] TPC hit\n", 
+      step->GetTrack()->GetParticleDefinition()->GetParticleName().data(), 
+      step->GetTrack()->GetTrackID());
+  //getchar(); 
+#endif
+
 
   G4double phEne = 0*CLHEP::eV;
 
@@ -133,7 +149,7 @@ G4bool SLArSuperCellSD::ProcessHits_constStep(const G4Step* step,
   {
     // Get the creation process of optical photon
     G4String procName = "";
-    if (track->GetTrackID() != 1) // make sure consider only secondaries
+    if (track->GetCreatorProcess()) // make sure consider only secondaries
     {
       procName = track->GetCreatorProcess()->GetProcessName();
     }

--- a/G4SOLAr/src/detector/TPC/SLArLArSD.cc
+++ b/G4SOLAr/src/detector/TPC/SLArLArSD.cc
@@ -141,7 +141,7 @@ G4bool SLArLArSD::ProcessHits(G4Step* step, G4TouchableHistory*)
             0.5*(postStepPoint->GetPosition()+preStepPoint->GetPosition()),
             postStepPoint->GetGlobalTime(), 
             anodeCfg, 
-            anaMngr->GetEvent()->GetEventAnodeByTPCID(fTPCID)); 
+            &anaMngr->GetEvent()->GetEventAnodeByTPCID(fTPCID)); 
       } else {
         printf("SLArLArSD::ProcessHits WARNING: Sensitive Detector TPC ID %i does not match with any TPC in the geometry\n", fTPCID);
         getchar(); 
@@ -155,11 +155,10 @@ G4bool SLArLArSD::ProcessHits(G4Step* step, G4TouchableHistory*)
     auto ancestor_id = eventAction->FindAncestorID(step->GetTrack()->GetTrackID()); 
 
     SLArMCPrimaryInfo* ancestor = nullptr;
-    //SLArMCPrimaryInfoPtr* ancestor = nullptr;
     auto primaries = anaMngr->GetEvent()->GetPrimaries();
     for (auto &p : primaries) {
-      if (p->GetTrackID() == ancestor_id) {
-        ancestor = p;
+      if (p.GetTrackID() == ancestor_id) {
+        ancestor = &p;
         break;
       }
     }

--- a/G4SOLAr/src/detector/TPC/SLArLArSD.cc
+++ b/G4SOLAr/src/detector/TPC/SLArLArSD.cc
@@ -136,7 +136,7 @@ G4bool SLArLArSD::ProcessHits(G4Step* step, G4TouchableHistory*)
     if (generatorAction->DoDriftElectrons()) {
 
       if (anodeCfg) {
-        runAction->GetElectronDrift()->Drift<SLArEventAnodePtr*&>(n_el, 
+        runAction->GetElectronDrift()->Drift<std::unique_ptr<SLArEventAnodeUniquePtr>&>(n_el, 
             step->GetTrack()->GetTrackID(), 
             0.5*(postStepPoint->GetPosition()+preStepPoint->GetPosition()),
             postStepPoint->GetGlobalTime(), 
@@ -154,12 +154,12 @@ G4bool SLArLArSD::ProcessHits(G4Step* step, G4TouchableHistory*)
       G4RunManager::GetRunManager()->GetUserEventAction(); 
     auto ancestor_id = eventAction->FindAncestorID(step->GetTrack()->GetTrackID()); 
 
-    //SLArMCPrimaryInfoUniquePtr* ancestor = nullptr;
-    SLArMCPrimaryInfoPtr* ancestor = nullptr;
+    SLArMCPrimaryInfoUniquePtr* ancestor = nullptr;
+    //SLArMCPrimaryInfoPtr* ancestor = nullptr;
     auto& primaries = anaMngr->GetEvent()->GetPrimaries();
     for (auto &p : primaries) {
       if (p->GetTrackID() == ancestor_id) {
-        ancestor = p;
+        ancestor = p.get();
         break;
       }
     }

--- a/G4SOLAr/src/detector/TPC/SLArLArSD.cc
+++ b/G4SOLAr/src/detector/TPC/SLArLArSD.cc
@@ -136,7 +136,7 @@ G4bool SLArLArSD::ProcessHits(G4Step* step, G4TouchableHistory*)
     if (generatorAction->DoDriftElectrons()) {
 
       if (anodeCfg) {
-        runAction->GetElectronDrift()->Drift<std::unique_ptr<SLArEventAnodeUniquePtr>&>(n_el, 
+        runAction->GetElectronDrift()->Drift(n_el, 
             step->GetTrack()->GetTrackID(), 
             0.5*(postStepPoint->GetPosition()+preStepPoint->GetPosition()),
             postStepPoint->GetGlobalTime(), 
@@ -154,12 +154,12 @@ G4bool SLArLArSD::ProcessHits(G4Step* step, G4TouchableHistory*)
       G4RunManager::GetRunManager()->GetUserEventAction(); 
     auto ancestor_id = eventAction->FindAncestorID(step->GetTrack()->GetTrackID()); 
 
-    SLArMCPrimaryInfoUniquePtr* ancestor = nullptr;
+    SLArMCPrimaryInfo* ancestor = nullptr;
     //SLArMCPrimaryInfoPtr* ancestor = nullptr;
-    auto& primaries = anaMngr->GetEvent()->GetPrimaries();
+    auto primaries = anaMngr->GetEvent()->GetPrimaries();
     for (auto &p : primaries) {
       if (p->GetTrackID() == ancestor_id) {
-        ancestor = p.get();
+        ancestor = p;
         break;
       }
     }

--- a/G4SOLAr/src/event/SLArEventAnode.cc
+++ b/G4SOLAr/src/event/SLArEventAnode.cc
@@ -1,20 +1,26 @@
 /**
  * @author      : Daniele Guffanti (daniele.guffanti@mib.infn.it)
  * @file        : SLArEventAnode.cc
- * @created     : mercoledì ago 10, 2022 14:39:21 CEST
+ * @created     : Wed Aug 10, 2022 14:39:21 CEST
  */
 
+#include <memory>
 #include "event/SLArEventAnode.hh"
 #include "config/SLArCfgMegaTile.hh"
 
-ClassImp(SLArEventAnode)
+templateClassImp(SLArEventAnode)
 
-SLArEventAnode::SLArEventAnode()
+template class SLArEventAnode<std::unique_ptr<SLArEventMegatileUniquePtr>, std::unique_ptr<SLArEventTileUniquePtr>, std::unique_ptr<SLArEventChargePixel>>;
+template class SLArEventAnode<SLArEventMegatilePtr*, SLArEventTilePtr*, SLArEventChargePixel*>;
+
+template<class M, class T, class P>
+SLArEventAnode<M, T, P>::SLArEventAnode()
   : fID(0), fNhits(0), fIsActive(true), 
     fLightBacktrackerRecordSize(0), fChargeBacktrackerRecordSize(0) 
 {}
 
-SLArEventAnode::SLArEventAnode(const SLArEventAnode& right) 
+template<>
+SLArEventAnodeUniquePtr::SLArEventAnode(const SLArEventAnode& right) 
   : TNamed(right) 
 {
   fID = right.fID; 
@@ -23,65 +29,120 @@ SLArEventAnode::SLArEventAnode(const SLArEventAnode& right)
   fLightBacktrackerRecordSize = right.fLightBacktrackerRecordSize;
   fChargeBacktrackerRecordSize = right.fChargeBacktrackerRecordSize;
   for (const auto &mgev : right.fMegaTilesMap) {
-    fMegaTilesMap.insert(
-        std::make_pair(mgev.first, (SLArEventMegatile*)mgev.second->Clone())
-        );
+    fMegaTilesMap[mgev.first] = std::make_unique<SLArEventMegatileUniquePtr>(*mgev.second);
   }
 }
 
-SLArEventAnode::SLArEventAnode(SLArCfgAnode* cfg) {
+template<>
+SLArEventAnodePtr::SLArEventAnode(const SLArEventAnodePtr& right) 
+  : TNamed(right) 
+{
+  fID = right.fID; 
+  fNhits = right.fNhits;
+  fIsActive = right.fIsActive; 
+  fLightBacktrackerRecordSize = right.fLightBacktrackerRecordSize;
+  fChargeBacktrackerRecordSize = right.fChargeBacktrackerRecordSize;
+  for (const auto &mgev : right.fMegaTilesMap) {
+    fMegaTilesMap[mgev.first] = new SLArEventMegatilePtr(*mgev.second);
+  }
+}
+
+template<class M, class T, class P>
+SLArEventAnode<M,T,P>::SLArEventAnode(SLArCfgAnode* cfg) {
   SetName(cfg->GetName()); 
   //ConfigSystem(cfg); 
   return;
 }
 
-SLArEventAnode::~SLArEventAnode() {
+template<>
+SLArEventAnodeUniquePtr::~SLArEventAnode() {
   for (auto &mgtile : fMegaTilesMap) {
-    delete mgtile.second; mgtile.second = nullptr;
+    mgtile.second->ResetHits();
   }
   fMegaTilesMap.clear(); 
 }
 
-int SLArEventAnode::ConfigSystem(SLArCfgAnode* cfg) {
+template<>
+SLArEventAnodePtr::~SLArEventAnode() {
+  for (auto &mgtile : fMegaTilesMap) {
+    mgtile.second->ResetHits();
+    delete mgtile.second;
+  }
+  fMegaTilesMap.clear(); 
+}
+
+template<>
+int SLArEventAnodeUniquePtr::ConfigSystem(SLArCfgAnode* cfg) {
   int imegatile = 0; 
   fID = cfg->GetIdx(); 
   for (const auto &mtcfg : cfg->GetMap()) {
     int megatile_idx = mtcfg.second->GetIdx(); 
     if (fMegaTilesMap.count(megatile_idx) == 0) {
-      fMegaTilesMap.insert(
-          std::make_pair(megatile_idx, 
-            new SLArEventMegatile(mtcfg.second))
-          );
+      std::unique_ptr<SLArEventMegatileUniquePtr> evMT = std::make_unique<SLArEventMegatileUniquePtr>(mtcfg.second);
+      fMegaTilesMap.insert( std::make_pair( megatile_idx, std::move(evMT) ) );
       imegatile++;
     }
   }
   return imegatile;
 }
 
-SLArEventMegatile* SLArEventAnode::CreateEventMegatile(const int mtIdx) {
-  if (fMegaTilesMap.count(mtIdx)) {
-    printf("SLArEventAnode::CreateEventMegatile(%i) WARNING: Megatile nr %i already present in anode %i register\n", mtIdx, mtIdx, fID);
-    return fMegaTilesMap.find(mtIdx)->second;
+template<>
+int SLArEventAnodePtr::ConfigSystem(SLArCfgAnode* cfg) {
+  int imegatile = 0; 
+  fID = cfg->GetIdx(); 
+  for (const auto &mtcfg : cfg->GetMap()) {
+    int megatile_idx = mtcfg.second->GetIdx(); 
+    if (fMegaTilesMap.count(megatile_idx) == 0) {
+      fMegaTilesMap.insert( std::make_pair( megatile_idx, new SLArEventMegatilePtr(mtcfg.second) ) );
+      imegatile++;
+    }
   }
-
-  auto mt_event = new SLArEventMegatile(); 
-  mt_event->SetIdx(mtIdx); 
-  mt_event->SetLightBacktrackerRecordSize( fLightBacktrackerRecordSize); 
-  mt_event->SetChargeBacktrackerRecordSize( fChargeBacktrackerRecordSize); 
-  fMegaTilesMap.insert( std::make_pair(mtIdx, mt_event) );  
-
-  return mt_event;
+  return imegatile;
 }
 
-SLArEventTile* SLArEventAnode::RegisterHit(SLArEventPhotonHit* hit) {
-  int mgtile_idx = hit->GetMegaTileIdx(); 
-  SLArEventMegatile* mt_event = nullptr;
-  if (fMegaTilesMap.count(mgtile_idx) == 0) mt_event = CreateEventMegatile(mgtile_idx);
-  else mt_event = fMegaTilesMap.find(mgtile_idx)->second;
 
-  auto t_event = mt_event->RegisterHit(hit);
-  fNhits++;
-  return t_event; 
+template<>
+std::unique_ptr<SLArEventMegatileUniquePtr>& SLArEventAnodeUniquePtr::GetOrCreateEventMegatile(const int mtIdx) {
+  auto it = fMegaTilesMap.find(mtIdx);
+  if (it != fMegaTilesMap.end()) {
+    //printf("SLArEventAnode::CreateEventMegatile(%i): Megatile nr %i already present in anode %i register\n", mtIdx, mtIdx, fID);
+    //getchar();
+    return fMegaTilesMap.find(mtIdx)->second;
+  }
+  else {
+    std::unique_ptr<SLArEventMegatileUniquePtr> mt_event = std::make_unique<SLArEventMegatileUniquePtr>();
+    mt_event->SetIdx(mtIdx); 
+    mt_event->SetLightBacktrackerRecordSize( fLightBacktrackerRecordSize); 
+    mt_event->SetChargeBacktrackerRecordSize( fChargeBacktrackerRecordSize); 
+    fMegaTilesMap.insert( std::make_pair(mtIdx, std::move(mt_event)) );  
+    return fMegaTilesMap[mtIdx];
+  }
+}
+
+template<>
+SLArEventMegatilePtr*& SLArEventAnodePtr::GetOrCreateEventMegatile(const int mtIdx) {
+  auto it = fMegaTilesMap.find(mtIdx);
+  if (it != fMegaTilesMap.end()) {
+    //printf("SLArEventAnode::CreateEventMegatile(%i): Megatile nr %i already present in anode %i register\n", mtIdx, mtIdx, fID);
+    //getchar();
+    return fMegaTilesMap.find(mtIdx)->second;
+  }
+  else {
+    SLArEventMegatilePtr* mt_event = new SLArEventMegatilePtr();
+    mt_event->SetIdx(mtIdx); 
+    mt_event->SetLightBacktrackerRecordSize( fLightBacktrackerRecordSize); 
+    mt_event->SetChargeBacktrackerRecordSize( fChargeBacktrackerRecordSize); 
+    fMegaTilesMap.insert( std::make_pair(mtIdx, std::move(mt_event)) );  
+    return fMegaTilesMap[mtIdx];
+  }
+}
+
+template<class M, class T, class P>
+T& SLArEventAnode<M,T,P>::RegisterHit(const SLArEventPhotonHit& hit) {
+  int mgtile_idx = hit.GetMegaTileIdx(); 
+  M& mt_event = GetOrCreateEventMegatile(mgtile_idx);
+  T& t_event = mt_event->RegisterHit(hit);
+  return (mt_event->GetTileMap()[t_event->GetIdx()]);
   //} else {
     //printf("SLArEventAnode::RegisterHit WARNING\n"); 
     //printf("Megatile with ID %i is not in store\n", mgtile_idx); 
@@ -90,19 +151,52 @@ SLArEventTile* SLArEventAnode::RegisterHit(SLArEventPhotonHit* hit) {
   //}
 }
 
-int SLArEventAnode::ResetHits() {
+template<class M, class T, class P>
+P& SLArEventAnode<M, T, P>::RegisterChargeHit(const SLArCfgAnode::SLArPixIdxCoord& pixID, const SLArEventChargeHit& hit) {
+  const int mgtile_idx = pixID.at(0);
+  const int tile_idx = pixID.at(1); 
+  const int pix_idx = pixID.at(2); 
+
+  M& mt_event = GetOrCreateEventMegatile(mgtile_idx); 
+  T& t_event = mt_event->GetOrCreateEventTile(tile_idx);
+  P& p_event = t_event->RegisterChargeHit(pix_idx, hit); 
+
+  return p_event;
+  //} else {
+    //printf("SLArEventAnode::RegisterHit WARNING\n"); 
+    //printf("Megatile with ID %i is not in store\n", mgtile_idx); 
+    //CreateEventMegatile(hit->GetMegaTileIdx());
+    //return 0; 
+  //}
+}
+
+template<>
+int SLArEventAnodeUniquePtr::ResetHits() {
   printf("SLArEventAnode::ResetHits() clear event on anode %i\n", fID);
   int nn = 0; 
   for (auto &mgtile : fMegaTilesMap) {
     nn += mgtile.second->ResetHits(); 
-    delete mgtile.second; mgtile.second = nullptr;
   }
 
   fMegaTilesMap.clear();
   return nn; 
 }
 
-void SLArEventAnode::SetActive(bool is_active) {
+template<>
+int SLArEventAnodePtr::ResetHits() {
+  printf("SLArEventAnode::ResetHits() clear event on anode %i\n", fID);
+  int nn = 0; 
+  for (auto &mgtile : fMegaTilesMap) {
+    nn += mgtile.second->ResetHits(); 
+    delete mgtile.second;
+  }
+
+  fMegaTilesMap.clear();
+  return nn; 
+}
+
+template<class M, class T, class P>
+void SLArEventAnode<M,T,P>::SetActive(bool is_active) {
   fIsActive = is_active; 
   for (auto &mgtile : fMegaTilesMap) {
     mgtile.second->SetActive(is_active); 

--- a/G4SOLAr/src/event/SLArEventAnode.cc
+++ b/G4SOLAr/src/event/SLArEventAnode.cc
@@ -72,6 +72,24 @@ SLArEventAnodePtr::~SLArEventAnode() {
 }
 
 template<>
+template<>
+void SLArEventAnodeUniquePtr::SoftCopy(SLArEventAnodePtr& record) const 
+{
+  record.SoftResetHits();
+  record.SetName(fName); 
+  record.SetID( fID ); 
+  record.SetNhits( fNhits ); 
+  record.SetActive( fIsActive ); 
+  record.SetLightBacktrackerRecordSize( fLightBacktrackerRecordSize ); 
+  record.SetChargeBacktrackerRecordSize( fChargeBacktrackerRecordSize ); 
+
+  for (const auto& mt : fMegaTilesMap) {
+    record.GetMegaTilesMap()[mt.first] = new SLArEventMegatilePtr(); 
+
+  }
+}
+
+template<>
 int SLArEventAnodeUniquePtr::ConfigSystem(SLArCfgAnode* cfg) {
   int imegatile = 0; 
   fID = cfg->GetIdx(); 
@@ -189,6 +207,19 @@ int SLArEventAnodePtr::ResetHits() {
   for (auto &mgtile : fMegaTilesMap) {
     nn += mgtile.second->ResetHits(); 
     delete mgtile.second;
+  }
+
+  fMegaTilesMap.clear();
+  return nn; 
+}
+
+
+template<class M, class T, class P>
+int SLArEventAnode<M,T,P>::SoftResetHits() {
+  printf("SLArEventAnode::ResetHits() clear event on anode %i\n", fID);
+  int nn = 0; 
+  for (auto &mgtile : fMegaTilesMap) {
+    nn += mgtile.second->SoftResetHits(); 
   }
 
   fMegaTilesMap.clear();

--- a/G4SOLAr/src/event/SLArEventBacktrackerRecord.cc
+++ b/G4SOLAr/src/event/SLArEventBacktrackerRecord.cc
@@ -5,6 +5,7 @@
  */
 
 #include "event/SLArEventBacktrackerRecord.hh"
+#include <cstdio>
 
 ClassImp(SLArEventBacktrackerRecord) 
 

--- a/G4SOLAr/src/event/SLArEventChargeHit.cc
+++ b/G4SOLAr/src/event/SLArEventChargeHit.cc
@@ -9,22 +9,17 @@
 ClassImp(SLArEventChargeHit)
 
 SLArEventChargeHit::SLArEventChargeHit()
-  : SLArEventGenericHit(), fTrkID(-1), fPrimaryID(-1) {}
+  : SLArEventGenericHit() {}
 
-SLArEventChargeHit::SLArEventChargeHit(float time, int trkId, int primaryID) 
-  : SLArEventGenericHit(), fTrkID(trkId), fPrimaryID(primaryID) {
-  fTime = time; 
-}
+SLArEventChargeHit::SLArEventChargeHit(float time, int trkID, int primaryID) 
+  : SLArEventGenericHit(time, trkID, primaryID) {}
 
 SLArEventChargeHit::SLArEventChargeHit(const SLArEventChargeHit& h)
   : SLArEventGenericHit(h) 
-{
-  fTrkID = h.fTrkID; 
-  fPrimaryID = h.fPrimaryID;
-}
+{}
 
 void SLArEventChargeHit::DumpInfo() {
   printf("charge hit at t = %g, trk id: %i, primaryID: %i\n", 
-      fTime, fTrkID, fPrimaryID);
+      fTime, fProducerTrkID, fPrimaryProducerTrkID);
 }
 

--- a/G4SOLAr/src/event/SLArEventChargePixel.cc
+++ b/G4SOLAr/src/event/SLArEventChargePixel.cc
@@ -14,7 +14,7 @@ SLArEventChargePixel::SLArEventChargePixel()
   fClockUnit = 10;
 }
 
-SLArEventChargePixel::SLArEventChargePixel(const int idx, const SLArEventChargeHit* hit)
+SLArEventChargePixel::SLArEventChargePixel(const int& idx, const SLArEventChargeHit& hit)
   : SLArEventHitsCollection<SLArEventChargeHit>(idx) 
 {
   fName = Form("EvPix%i", fIdx); 
@@ -22,4 +22,6 @@ SLArEventChargePixel::SLArEventChargePixel(const int idx, const SLArEventChargeH
   RegisterHit(hit); 
 }
 
-
+SLArEventChargePixel::SLArEventChargePixel(const SLArEventChargePixel& right) 
+  : SLArEventHitsCollection<SLArEventChargeHit>(right) 
+{}

--- a/G4SOLAr/src/event/SLArEventChargePixel.cc
+++ b/G4SOLAr/src/event/SLArEventChargePixel.cc
@@ -11,14 +11,14 @@ ClassImp(SLArEventChargePixel)
 SLArEventChargePixel::SLArEventChargePixel() 
   : SLArEventHitsCollection<SLArEventChargeHit>()
 {
-  fClockUnit = 10;
+  fClockUnit = 50;
 }
 
 SLArEventChargePixel::SLArEventChargePixel(const int& idx, const SLArEventChargeHit& hit)
   : SLArEventHitsCollection<SLArEventChargeHit>(idx) 
 {
   fName = Form("EvPix%i", fIdx); 
-  fClockUnit = 10; 
+  fClockUnit = 50; 
   RegisterHit(hit); 
 }
 

--- a/G4SOLAr/src/event/SLArEventGenericHit.cc
+++ b/G4SOLAr/src/event/SLArEventGenericHit.cc
@@ -11,6 +11,10 @@ ClassImp(SLArEventGenericHit)
 SLArEventGenericHit::SLArEventGenericHit()
   : fTime(-1), fProducerTrkID(-1), fPrimaryProducerTrkID(-1) {}
 
+SLArEventGenericHit::SLArEventGenericHit(float t, int prodTrkID, int primaryTrkID)
+  : fTime(t), fProducerTrkID(prodTrkID), fPrimaryProducerTrkID(primaryTrkID) {}
+
+
 SLArEventGenericHit::SLArEventGenericHit(const SLArEventGenericHit& other) 
   : TObject(other) 
 {

--- a/G4SOLAr/src/event/SLArEventHitsCollection.cc
+++ b/G4SOLAr/src/event/SLArEventHitsCollection.cc
@@ -47,6 +47,26 @@ SLArEventHitsCollection<T>::~SLArEventHitsCollection() {
 }
 
 template<class T>
+void SLArEventHitsCollection<T>::Copy(SLArEventHitsCollection& record) const 
+{
+  record.SetBacktrackerRecordSize( fBacktrackerRecordSize ); 
+  record.SetIdx( fIdx ); 
+  record.SetActive( fIsActive ); 
+  record.SetClockUnit( fClockUnit ); 
+  record.SetNhits( fNhits ); 
+
+  for (const auto &hit : fHits) {
+    record.GetHits()[hit.first] = hit.second;
+  }   
+
+  for (const auto &bktv : fBacktrackerCollections) {
+    record.GetBacktrackerRecordCollection()[bktv.first] = bktv.second;
+  }
+
+  return;
+}
+
+template<class T>
 int SLArEventHitsCollection<T>::RegisterHit(const T hit) {
   fHits[ConvertToClock<float>(hit.GetTime())]++; 
   fNhits++; 

--- a/G4SOLAr/src/event/SLArEventHitsCollection.cc
+++ b/G4SOLAr/src/event/SLArEventHitsCollection.cc
@@ -122,6 +122,23 @@ SLArEventBacktrackerVector& SLArEventHitsCollection<T>::GetBacktrackerVector(USh
   return bkt_vector;
 }
 
+template<class T> 
+int SLArEventHitsCollection<T>::ZeroSuppression(const UShort_t threshold) {
+  int hits_erased = 0; 
+  //printf("ZeroSuppression threshold = %u\n", threshold);
+  for (auto it = fHits.begin(); it != fHits.end(); ) {
+    if (it->second < threshold) {
+      auto key = it->first;
+      //printf("deleting map entry with key [%u] having %u hits\n", key, it->second);
+      fBacktrackerCollections.erase(key);
+      hits_erased += it->second;
+      it = fHits.erase(it);
+    } else {
+      ++it;
+    }
+  }
+  return hits_erased;
+}
 
 template class SLArEventHitsCollection<SLArEventPhotonHit>; 
 template class SLArEventHitsCollection<SLArEventChargeHit>; 

--- a/G4SOLAr/src/event/SLArEventHitsCollection.cc
+++ b/G4SOLAr/src/event/SLArEventHitsCollection.cc
@@ -47,9 +47,8 @@ SLArEventHitsCollection<T>::~SLArEventHitsCollection() {
 }
 
 template<class T>
-int SLArEventHitsCollection<T>::RegisterHit(const T* hit) {
-  if (!hit) return -1; 
-  fHits[ConvertToClock<float>(hit->GetTime())]++; 
+int SLArEventHitsCollection<T>::RegisterHit(const T hit) {
+  fHits[ConvertToClock<float>(hit.GetTime())]++; 
   fNhits++; 
   return fNhits;
 }
@@ -72,7 +71,7 @@ int SLArEventHitsCollection<T>::ResetHits() {
 }
 
 template<class T>
-void SLArEventHitsCollection<T>::PrintHits() {
+void SLArEventHitsCollection<T>::PrintHits() const {
   printf("Hit container ID: %i [%s]\n", fIdx, fName.Data());
   printf("- - - - - - - - - - - - - - - - - - - - - - -\n");
   for (auto &hit : fHits) {

--- a/G4SOLAr/src/event/SLArEventHitsCollection.cc
+++ b/G4SOLAr/src/event/SLArEventHitsCollection.cc
@@ -101,19 +101,22 @@ void SLArEventHitsCollection<T>::PrintHits() const {
 }
 
 template<class T>
-SLArEventBacktrackerVector* SLArEventHitsCollection<T>::GetBacktrackerVector(UShort_t key) {
-  
-  auto bkt_vector = &(fBacktrackerCollections[key]);
-  if (bkt_vector->IsEmpty() == false) return bkt_vector;
-  else if (bkt_vector->IsEmpty() && fBacktrackerRecordSize <= 0) {
-    printf("BacktrackerRecordSize is %u. I should not be here...\n", 
-        fBacktrackerRecordSize);
-    return nullptr;
+SLArEventBacktrackerVector& SLArEventHitsCollection<T>::GetBacktrackerVector(UShort_t key) {
+  //printf("SLArEventHitsCollection[%i]::GetBacktrackerVector[%u]\n", fIdx, key);
+  auto& bkt_vector = fBacktrackerCollections[key];
+  if (bkt_vector.IsEmpty() == false) {
+    //printf("[%i] Already have a backtrackervector at key: %u\n", fIdx, key);
+    return bkt_vector;
   }
-  else if (bkt_vector->IsEmpty() && fBacktrackerRecordSize > 0) {
+  else if (bkt_vector.IsEmpty() && fBacktrackerRecordSize <= 0) {
+    //printf("BacktrackerRecordSize is %u. I should not be here...\n", 
+        //fBacktrackerRecordSize);
+    throw 4;
+  }
+  else if (bkt_vector.IsEmpty() && fBacktrackerRecordSize > 0) {
     //printf("initializing backtracker records vector to size %u\n", 
         //fBacktrackerRecordSize);
-    bkt_vector->InitRecords(fBacktrackerRecordSize);
+    bkt_vector.InitRecords(fBacktrackerRecordSize);
   }
 
   return bkt_vector;

--- a/G4SOLAr/src/event/SLArEventMegatile.cc
+++ b/G4SOLAr/src/event/SLArEventMegatile.cc
@@ -57,6 +57,27 @@ SLArEventMegatile<T>::SLArEventMegatile(SLArCfgMegaTile* cfg)
   //ConfigModule(cfg); 
 }
 
+
+template<>
+template<>
+void SLArEventMegatileUniquePtr::SoftCopy(SLArEventMegatilePtr& record) const
+{
+  record.SoftResetHits(); 
+  record.SetName( fName ); 
+  record.SetActive( fIsActive ); 
+  record.SetIdx( fIdx ); 
+  record.SetLightBacktrackerRecordSize( fLightBacktrackerRecordSize ); 
+  record.SetChargeBacktrackerRecordSize( fChargeBacktrackerRecordSize ); 
+  
+  for (const auto &tile : fTilesMap) {
+    record.GetTileMap()[tile.first] = new SLArEventTilePtr();
+    tile.second->SoftCopy( *record.GetTileMap()[tile.first] );
+  }
+
+  return;
+}
+
+
 template<>
 int SLArEventMegatilePtr::ResetHits() {
   int nhits = 0;
@@ -76,6 +97,19 @@ int SLArEventMegatileUniquePtr::ResetHits() {
   for (auto &tile : fTilesMap) {
     nhits += tile.second->GetNhits(); 
     tile.second->ResetHits(); 
+  }
+
+  fTilesMap.clear();
+  
+  return nhits; 
+}
+
+template<class T>
+int SLArEventMegatile<T>::SoftResetHits() {
+  int nhits = 0;
+  for (auto &tile : fTilesMap) {
+    nhits += tile.second->GetNhits(); 
+    tile.second->SoftResetHits(); 
   }
 
   fTilesMap.clear();

--- a/G4SOLAr/src/event/SLArEventMegatile.cc
+++ b/G4SOLAr/src/event/SLArEventMegatile.cc
@@ -42,9 +42,9 @@ SLArEventMegatile::SLArEventMegatile(SLArCfgMegaTile* cfg)
 int SLArEventMegatile::ResetHits() {
   int nhits = 0;
   for (auto &tile : fTilesMap) {
-    nhits += tile.second->GetNhits(); 
-    tile.second->ResetHits(); 
-    delete tile.second;
+    nhits += tile.second.GetNhits(); 
+    tile.second.ResetHits(); 
+    //delete tile.second;
   }
 
   fTilesMap.clear();
@@ -56,14 +56,14 @@ int SLArEventMegatile::ResetHits() {
 SLArEventMegatile::~SLArEventMegatile()
 {
   ResetHits();
-  fTilesMap.clear(); 
+  //fTilesMap.clear(); 
 }
 
 int SLArEventMegatile::ConfigModule(const SLArCfgMegaTile* cfg) {
   int ntiles = 0; 
   for (auto &cfgTile : cfg->GetConstMap()) {
     int idx_tile = cfgTile.second->GetIdx(); 
-    fTilesMap.insert(std::make_pair(idx_tile, new SLArEventTile(idx_tile) ));
+    fTilesMap.insert(std::make_pair(idx_tile, SLArEventTile(idx_tile) ));
     ++ntiles; 
   }
 
@@ -71,7 +71,7 @@ int SLArEventMegatile::ConfigModule(const SLArCfgMegaTile* cfg) {
 }
 
 
-SLArEventTile* SLArEventMegatile::GetOrCreateEventTile(const int& tileIdx) 
+SLArEventTile& SLArEventMegatile::GetOrCreateEventTile(const int& tileIdx) 
 {
   auto it  = fTilesMap.find(tileIdx); 
   if (it != fTilesMap.end()) {
@@ -79,28 +79,28 @@ SLArEventTile* SLArEventMegatile::GetOrCreateEventTile(const int& tileIdx)
     return fTilesMap.find(tileIdx)->second;
   }
   else {
-    fTilesMap.insert( std::make_pair(tileIdx, new SLArEventTile(tileIdx) ) );  
+    fTilesMap.insert( std::make_pair(tileIdx, SLArEventTile(tileIdx) ) );  
     auto& t_event = fTilesMap[tileIdx];
-    t_event->SetBacktrackerRecordSize( fLightBacktrackerRecordSize ); 
-    t_event->SetChargeBacktrackerRecordSize( fChargeBacktrackerRecordSize ); 
+    t_event.SetBacktrackerRecordSize( fLightBacktrackerRecordSize ); 
+    t_event.SetChargeBacktrackerRecordSize( fChargeBacktrackerRecordSize ); 
     return t_event;
   }
 }
 
 
-SLArEventTile* SLArEventMegatile::RegisterHit(const SLArEventPhotonHit& hit) {
+SLArEventTile& SLArEventMegatile::RegisterHit(const SLArEventPhotonHit& hit) {
   int tile_idx = hit.GetTileIdx(); 
   fNhits++; 
 
-  auto tile_ev = GetOrCreateEventTile(tile_idx);
-  tile_ev->RegisterHit(hit);
+  auto& tile_ev = GetOrCreateEventTile(tile_idx);
+  tile_ev.RegisterHit(hit);
   return tile_ev;
 }
 
 int SLArEventMegatile::GetNPhotonHits() const {
   int nhits = 0;
   for (const auto &tile : fTilesMap) {
-    nhits += tile.second->GetNhits(); 
+    nhits += tile.second.GetNhits(); 
   }
 
   return nhits; 
@@ -109,7 +109,7 @@ int SLArEventMegatile::GetNPhotonHits() const {
 int SLArEventMegatile::GetNChargeHits() const {
   int nhits = 0;
   for (const auto &tile : fTilesMap) {
-    nhits += tile.second->GetPixelHits(); 
+    nhits += tile.second.GetPixelHits(); 
   }
 
   return nhits; 
@@ -118,7 +118,7 @@ int SLArEventMegatile::GetNChargeHits() const {
 
 void SLArEventMegatile::SetActive(bool is_active) {
   for (auto &tile : fTilesMap) {
-    tile.second->SetActive(is_active); 
+    tile.second.SetActive(is_active); 
   } 
   return;
 }

--- a/G4SOLAr/src/event/SLArEventSuperCell.cc
+++ b/G4SOLAr/src/event/SLArEventSuperCell.cc
@@ -46,7 +46,7 @@ double SLArEventSuperCell::GetTime(EPhProcess proc) const {
 
 }
 
-void SLArEventSuperCell::PrintHits()
+void SLArEventSuperCell::PrintHits() const
 {
   std::cout << "SuperCell id: " << fIdx << std::endl;
   std::cout << "-----------------------------------------"

--- a/G4SOLAr/src/event/SLArEventSuperCellArray.cc
+++ b/G4SOLAr/src/event/SLArEventSuperCellArray.cc
@@ -19,7 +19,7 @@ SLArEventSuperCellArray::SLArEventSuperCellArray(const SLArEventSuperCellArray& 
   fIsActive = ev.fIsActive; 
   for (const auto &sc : ev.fSuperCellMap) {
     fSuperCellMap.insert(
-        std::make_pair(sc.first, new SLArEventSuperCell(*sc.second) ) );
+        std::make_pair(sc.first, SLArEventSuperCell(sc.second) ) );
   }
   return;
 }
@@ -34,8 +34,8 @@ SLArEventSuperCellArray::SLArEventSuperCellArray(SLArCfgSuperCellArray* cfg)
 
 SLArEventSuperCellArray::~SLArEventSuperCellArray() {
   for (auto &scevent : fSuperCellMap) {
-    scevent.second->ResetHits();
-    delete scevent.second;
+    scevent.second.ResetHits();
+    //delete scevent.second;
   }
   fSuperCellMap.clear(); 
 }
@@ -44,7 +44,7 @@ int SLArEventSuperCellArray::ConfigSystem(SLArCfgSuperCellArray* cfg) {
   int nsc = 0; 
   for (const auto &sc : cfg->GetMap()) {
       if (fSuperCellMap.count(sc.first) == 0) {
-        fSuperCellMap.insert( std::make_pair(sc.first, new SLArEventSuperCell(sc.first)) ); 
+        fSuperCellMap.insert( std::make_pair(sc.first, SLArEventSuperCell(sc.first)) ); 
         nsc++;
     }
   }
@@ -52,7 +52,7 @@ int SLArEventSuperCellArray::ConfigSystem(SLArCfgSuperCellArray* cfg) {
   return nsc; 
 }
 
-SLArEventSuperCell* SLArEventSuperCellArray::GetOrCreateEventSuperCell(const int scIdx) {
+SLArEventSuperCell& SLArEventSuperCellArray::GetOrCreateEventSuperCell(const int scIdx) {
   auto it = fSuperCellMap.find(scIdx); 
 
   if (it != fSuperCellMap.end()) {
@@ -60,18 +60,18 @@ SLArEventSuperCell* SLArEventSuperCellArray::GetOrCreateEventSuperCell(const int
     return fSuperCellMap.find(scIdx)->second;
   }
   else {
-    fSuperCellMap.insert( std::make_pair(scIdx, new SLArEventSuperCell(scIdx)) );
-    auto sc_event = fSuperCellMap[scIdx];
-    sc_event->SetBacktrackerRecordSize( fLightBacktrackerRecordSize ); 
+    fSuperCellMap.insert( std::make_pair(scIdx, SLArEventSuperCell(scIdx)) );
+    auto& sc_event = fSuperCellMap[scIdx];
+    sc_event.SetBacktrackerRecordSize( fLightBacktrackerRecordSize ); 
 
     return sc_event;
   }
 }
 
-SLArEventSuperCell* SLArEventSuperCellArray::RegisterHit(const SLArEventPhotonHit& hit) {
+SLArEventSuperCell& SLArEventSuperCellArray::RegisterHit(const SLArEventPhotonHit& hit) {
   int sc_idx = hit.GetTileIdx(); 
-  auto sc_event = GetOrCreateEventSuperCell(sc_idx);
-  sc_event->RegisterHit(hit); 
+  auto& sc_event = GetOrCreateEventSuperCell(sc_idx);
+  sc_event.RegisterHit(hit); 
 
   fNhits++;
   return sc_event;
@@ -87,7 +87,7 @@ SLArEventSuperCell* SLArEventSuperCellArray::RegisterHit(const SLArEventPhotonHi
 int SLArEventSuperCellArray::ResetHits() {
   int nn = 0; 
   for (auto &sc : fSuperCellMap) {
-    nn += sc.second->ResetHits(); 
+    nn += sc.second.ResetHits(); 
   }
   fSuperCellMap.clear();
   fNhits = 0; 
@@ -98,7 +98,7 @@ int SLArEventSuperCellArray::ResetHits() {
 void SLArEventSuperCellArray::SetActive(bool is_active) {
   fIsActive = is_active; 
   for (auto &sc : fSuperCellMap) {
-    sc.second->SetActive(is_active); 
+    sc.second.SetActive(is_active); 
   }
 }
 

--- a/G4SOLAr/src/event/SLArEventSuperCellArray.cc
+++ b/G4SOLAr/src/event/SLArEventSuperCellArray.cc
@@ -172,6 +172,18 @@ int SLArEventSuperCellArrayUniquePtr::ResetHits() {
 }
 
 template<class S>
+int SLArEventSuperCellArray<S>::SoftResetHits() {
+  int nn = 0; 
+  for (auto &sc : fSuperCellMap) {
+    nn += sc.second->ResetHits(); 
+  }
+  fSuperCellMap.clear();
+  fNhits = 0; 
+  return nn; 
+}
+
+
+template<class S>
 void SLArEventSuperCellArray<S>::SetActive(bool is_active) {
   fIsActive = is_active; 
   for (auto &sc : fSuperCellMap) {

--- a/G4SOLAr/src/event/SLArEventTile.cc
+++ b/G4SOLAr/src/event/SLArEventTile.cc
@@ -4,45 +4,94 @@
  * @created     : mercoledì ago 10, 2022 12:21:15 CEST
  */
 
+#include <memory>
 #include "event/SLArEventTile.hh"
 
-ClassImp(SLArEventTile)
+templateClassImp(SLArEventTile)
 
-SLArEventTile::SLArEventTile() 
-  : SLArEventHitsCollection<SLArEventPhotonHit>(), fChargeBacktrackerRecordSize(0) {}
+template class SLArEventTile<SLArEventChargePixel*>; 
+template class SLArEventTile<std::unique_ptr<SLArEventChargePixel>>;
+
+template<class P>
+SLArEventTile<P>::SLArEventTile() 
+  : SLArEventHitsCollection<SLArEventPhotonHit>(), fChargeBacktrackerRecordSize(0) 
+{}
 
 
-SLArEventTile::SLArEventTile(const int idx) 
+template<class P>
+SLArEventTile<P>::SLArEventTile(const int idx) 
   : SLArEventHitsCollection<SLArEventPhotonHit>(idx), fChargeBacktrackerRecordSize(0) 
 {
   fName = Form("EvTile%i", fIdx); 
 }
 
 
-SLArEventTile::SLArEventTile(const SLArEventTile& ev) 
+template<>
+SLArEventTileUniquePtr::SLArEventTile(const SLArEventTile& ev) 
   : SLArEventHitsCollection<SLArEventPhotonHit>(ev), fChargeBacktrackerRecordSize(0)
 {
   fChargeBacktrackerRecordSize = ev.fChargeBacktrackerRecordSize;
   if (!ev.fPixelHits.empty()) {
     for (const auto &qhit : ev.fPixelHits) {
-      fPixelHits.insert(
-          std::make_pair(qhit.first, (SLArEventChargePixel*)qhit.second->Clone()));
+      fPixelHits[qhit.first] = std::make_unique<SLArEventChargePixel>(*qhit.second);
     }
   }
 }
 
-SLArEventTile::~SLArEventTile() {
+template<>
+SLArEventTilePtr::SLArEventTile(const SLArEventTile& ev) 
+  : SLArEventHitsCollection<SLArEventPhotonHit>(ev), fChargeBacktrackerRecordSize(0)
+{
+  fChargeBacktrackerRecordSize = ev.fChargeBacktrackerRecordSize;
+  if (!ev.fPixelHits.empty()) {
+    for (const auto &qhit : ev.fPixelHits) {
+      fPixelHits[qhit.first] = new SLArEventChargePixel(*qhit.second);
+    }
+  }
+}
+
+template<>
+int SLArEventTileUniquePtr::ResetHits()
+{
+  SLArEventHitsCollection::ResetHits();
+
+  for (auto &pix : fPixelHits) {
+      pix.second->ResetHits(); 
+  }
+  fPixelHits.clear(); 
+
+  return fHits.size();
+}
+
+template<>
+int SLArEventTilePtr::ResetHits()
+{
+  SLArEventHitsCollection::ResetHits();
+
+  for (auto &pix : fPixelHits) {
+    pix.second->ResetHits(); 
+    delete pix.second;
+  }
+  fPixelHits.clear(); 
+
+  return fHits.size();
+}
+
+template<class P>
+SLArEventTile<P>::~SLArEventTile() {
   ResetHits();
 }
 
-double SLArEventTile::GetTime() const {
+template<class P>
+double SLArEventTile<P>::GetTime() const {
   double t = -1;
   if (fNhits > 0) t = fHits.begin()->first * fClockUnit;
 
   return t;
 }
 
-double SLArEventTile::GetTime(EPhProcess proc) const {
+template<class P>
+double SLArEventTile<P>::GetTime(EPhProcess proc) const {
   double t = -1;
   printf("TO BE FIXED\n");
   //if (proc == kCher)
@@ -74,22 +123,9 @@ double SLArEventTile::GetTime(EPhProcess proc) const {
   //return true;
 //}
 
-int SLArEventTile::ResetHits()
-{
-  SLArEventHitsCollection::ResetHits();
 
-  for (auto &pix : fPixelHits) {
-    if (pix.second) {
-      pix.second->ResetHits(); 
-      delete pix.second;
-    }
-  }
-  fPixelHits.clear(); 
-
-  return fHits.size();
-}
-
-void SLArEventTile::PrintHits()
+template<class P>
+void SLArEventTile<P>::PrintHits() const
 {
   printf("*********************************************\n");
   printf("Hit container ID: %i [%s]\n", fIdx, fName.Data());
@@ -106,25 +142,48 @@ void SLArEventTile::PrintHits()
   return;
 }
 
-SLArEventChargePixel* SLArEventTile::RegisterChargeHit(const int pixID, const SLArEventChargeHit* qhit) {
-  SLArEventChargePixel* pixEv = nullptr;
-  if (fPixelHits.count(pixID)) {
+template<>
+std::unique_ptr<SLArEventChargePixel>& SLArEventTileUniquePtr::RegisterChargeHit(const int& pixID, const SLArEventChargeHit& qhit) {
+  
+  auto it = fPixelHits.find(pixID);
+
+  if (it != fPixelHits.end()) {
     //printf("SLArEventTile::RegisterChargeHit(%i): pixel %i already hit.\n", pixID, pixID);
-    pixEv = fPixelHits[pixID];
-    pixEv->RegisterHit(qhit); 
+    it->second->RegisterHit(qhit); 
+    return it->second;
   }
   else {
-    //printf("SLArEventTile::RegisterChargeHit(%i): pixel %i already hit.\n", pixID, pixID);
-    pixEv = new SLArEventChargePixel(pixID, qhit); 
+    //printf("SLArEventTile::RegisterChargeHit(%i): creating new pixel hit collection.\n", pixID);
+    std::unique_ptr<SLArEventChargePixel> pixEv = std::make_unique<SLArEventChargePixel>(pixID, qhit); 
     pixEv->SetBacktrackerRecordSize( fChargeBacktrackerRecordSize ); 
-    fPixelHits.insert(std::make_pair(pixID, pixEv));
+    fPixelHits.insert(std::make_pair(pixID, std::move(pixEv)));
+    return fPixelHits[pixID];
   }
 
-  //printf("SLArEventTile::RegisterChargeHit(%i): DONE.\n", pixID);
-  return pixEv; 
 }
 
-double SLArEventTile::GetPixelHits() const {
+template<>
+SLArEventChargePixel*& SLArEventTilePtr::RegisterChargeHit(const int& pixID, const SLArEventChargeHit& qhit) {
+  
+  auto it = fPixelHits.find(pixID);
+
+  if (it != fPixelHits.end()) {
+    //printf("SLArEventTile::RegisterChargeHit(%i): pixel %i already hit.\n", pixID, pixID);
+    it->second->RegisterHit(qhit); 
+    return it->second;
+  }
+  else {
+    //printf("SLArEventTile::RegisterChargeHit(%i): creating new pixel hit collection.\n", pixID);
+    SLArEventChargePixel* pixEv = new SLArEventChargePixel(pixID, qhit); 
+    pixEv->SetBacktrackerRecordSize( fChargeBacktrackerRecordSize ); 
+    fPixelHits.insert(std::make_pair(pixID, std::move(pixEv)));
+    return fPixelHits[pixID];
+  }
+
+}
+
+template<class P>
+double SLArEventTile<P>::GetPixelHits() const {
   double nhits = 0.;
   for (const auto &pixel : fPixelHits) {
     nhits += pixel.second->GetNhits(); 

--- a/G4SOLAr/src/event/SLArEventTile.cc
+++ b/G4SOLAr/src/event/SLArEventTile.cc
@@ -39,8 +39,8 @@ int SLArEventTile::ResetHits()
   SLArEventHitsCollection::ResetHits();
 
   for (auto &pix : fPixelHits) {
-      pix.second->ResetHits(); 
-      delete pix.second;
+      pix.second.ResetHits(); 
+      //delete pix.second;
   }
   fPixelHits.clear(); 
 
@@ -101,28 +101,28 @@ void SLArEventTile::PrintHits() const
   }
   if (!fPixelHits.empty()) {
     printf("Pixel readout hits:\n");
-    for (const auto &pix : fPixelHits) pix.second->PrintHits(); 
+    for (const auto &pix : fPixelHits) pix.second.PrintHits(); 
   }
 
   printf("\n"); 
   return;
 }
 
-SLArEventChargePixel* SLArEventTile::RegisterChargeHit(const int& pixID, const SLArEventChargeHit& qhit) {
+SLArEventChargePixel& SLArEventTile::RegisterChargeHit(const int& pixID, const SLArEventChargeHit& qhit) {
   
   auto it = fPixelHits.find(pixID);
 
   if (it != fPixelHits.end()) {
     //printf("SLArEventTile::RegisterChargeHit(%i): pixel %i already hit.\n", pixID, pixID);
-    it->second->RegisterHit(qhit); 
+    it->second.RegisterHit(qhit); 
     return it->second;
   }
   else {
     //printf("SLArEventTile::RegisterChargeHit(%i): creating new pixel hit collection.\n", pixID);
-    fPixelHits.insert(std::make_pair(pixID, new SLArEventChargePixel(pixID, qhit)));
-    //printf("SLArEventTile::RegisterChargeHit(%i): setting backtracker size to %u.\n", pixID, fChargeBacktrackerRecordSize);
-    fPixelHits[pixID]->SetBacktrackerRecordSize( fChargeBacktrackerRecordSize ); 
-    return fPixelHits[pixID];
+    fPixelHits.insert(std::make_pair(pixID, SLArEventChargePixel(pixID, qhit)));
+    auto& pixEv = fPixelHits[pixID];
+    pixEv.SetBacktrackerRecordSize( fChargeBacktrackerRecordSize ); 
+    return pixEv;  
   }
 
 }
@@ -130,7 +130,7 @@ SLArEventChargePixel* SLArEventTile::RegisterChargeHit(const int& pixID, const S
 double SLArEventTile::GetPixelHits() const {
   double nhits = 0.;
   for (const auto &pixel : fPixelHits) {
-    nhits += pixel.second->GetNhits(); 
+    nhits += pixel.second.GetNhits(); 
   }
 
   return nhits; 

--- a/G4SOLAr/src/event/SLArEventTile.cc
+++ b/G4SOLAr/src/event/SLArEventTile.cc
@@ -77,6 +77,19 @@ int SLArEventTilePtr::ResetHits()
   return fHits.size();
 }
 
+template<class P> 
+int SLArEventTile<P>::SoftResetHits() 
+{
+  SLArEventHitsCollection::ResetHits();
+
+  for (auto &pix : fPixelHits) {
+      pix.second->ResetHits(); 
+  }
+  fPixelHits.clear(); 
+
+  return fHits.size();
+}
+
 template<class P>
 SLArEventTile<P>::~SLArEventTile() {
   ResetHits();

--- a/G4SOLAr/src/event/SLArEventTile.cc
+++ b/G4SOLAr/src/event/SLArEventTile.cc
@@ -7,104 +7,59 @@
 #include <memory>
 #include "event/SLArEventTile.hh"
 
-templateClassImp(SLArEventTile)
+ClassImp(SLArEventTile)
 
-template class SLArEventTile<SLArEventChargePixel*>; 
-template class SLArEventTile<std::unique_ptr<SLArEventChargePixel>>;
 
-template<class P>
-SLArEventTile<P>::SLArEventTile() 
-  : SLArEventHitsCollection<SLArEventPhotonHit>(), fChargeBacktrackerRecordSize(0) 
+SLArEventTile::SLArEventTile() 
+  : SLArEventHitsCollection<SLArEventPhotonHit>(), fChargeBacktrackerRecordSize(0)
 {}
 
 
-template<class P>
-SLArEventTile<P>::SLArEventTile(const int idx) 
+SLArEventTile::SLArEventTile(const int idx) 
   : SLArEventHitsCollection<SLArEventPhotonHit>(idx), fChargeBacktrackerRecordSize(0) 
 {
   fName = Form("EvTile%i", fIdx); 
 }
 
-
-template<>
-SLArEventTileUniquePtr::SLArEventTile(const SLArEventTile& ev) 
+SLArEventTile::SLArEventTile(const SLArEventTile& ev) 
   : SLArEventHitsCollection<SLArEventPhotonHit>(ev), fChargeBacktrackerRecordSize(0)
 {
   fChargeBacktrackerRecordSize = ev.fChargeBacktrackerRecordSize;
   if (!ev.fPixelHits.empty()) {
     for (const auto &qhit : ev.fPixelHits) {
-      fPixelHits[qhit.first] = std::make_unique<SLArEventChargePixel>(*qhit.second);
+      fPixelHits[qhit.first] = qhit.second;
     }
   }
 }
 
-template<>
-SLArEventTilePtr::SLArEventTile(const SLArEventTile& ev) 
-  : SLArEventHitsCollection<SLArEventPhotonHit>(ev), fChargeBacktrackerRecordSize(0)
-{
-  fChargeBacktrackerRecordSize = ev.fChargeBacktrackerRecordSize;
-  if (!ev.fPixelHits.empty()) {
-    for (const auto &qhit : ev.fPixelHits) {
-      fPixelHits[qhit.first] = new SLArEventChargePixel(*qhit.second);
-    }
-  }
-}
 
-template<>
-int SLArEventTileUniquePtr::ResetHits()
+
+int SLArEventTile::ResetHits()
 {
   SLArEventHitsCollection::ResetHits();
 
   for (auto &pix : fPixelHits) {
       pix.second->ResetHits(); 
+      delete pix.second;
   }
   fPixelHits.clear(); 
 
   return fHits.size();
 }
 
-template<>
-int SLArEventTilePtr::ResetHits()
-{
-  SLArEventHitsCollection::ResetHits();
 
-  for (auto &pix : fPixelHits) {
-    pix.second->ResetHits(); 
-    delete pix.second;
-  }
-  fPixelHits.clear(); 
-
-  return fHits.size();
-}
-
-template<class P> 
-int SLArEventTile<P>::SoftResetHits() 
-{
-  SLArEventHitsCollection::ResetHits();
-
-  for (auto &pix : fPixelHits) {
-      pix.second->ResetHits(); 
-  }
-  fPixelHits.clear(); 
-
-  return fHits.size();
-}
-
-template<class P>
-SLArEventTile<P>::~SLArEventTile() {
+SLArEventTile::~SLArEventTile() {
   ResetHits();
 }
 
-template<class P>
-double SLArEventTile<P>::GetTime() const {
+double SLArEventTile::GetTime() const {
   double t = -1;
   if (fNhits > 0) t = fHits.begin()->first * fClockUnit;
 
   return t;
 }
 
-template<class P>
-double SLArEventTile<P>::GetTime(EPhProcess proc) const {
+double SLArEventTile::GetTime(EPhProcess proc) const {
   double t = -1;
   printf("TO BE FIXED\n");
   //if (proc == kCher)
@@ -136,9 +91,7 @@ double SLArEventTile<P>::GetTime(EPhProcess proc) const {
   //return true;
 //}
 
-
-template<class P>
-void SLArEventTile<P>::PrintHits() const
+void SLArEventTile::PrintHits() const
 {
   printf("*********************************************\n");
   printf("Hit container ID: %i [%s]\n", fIdx, fName.Data());
@@ -155,8 +108,7 @@ void SLArEventTile<P>::PrintHits() const
   return;
 }
 
-template<>
-std::unique_ptr<SLArEventChargePixel>& SLArEventTileUniquePtr::RegisterChargeHit(const int& pixID, const SLArEventChargeHit& qhit) {
+SLArEventChargePixel* SLArEventTile::RegisterChargeHit(const int& pixID, const SLArEventChargeHit& qhit) {
   
   auto it = fPixelHits.find(pixID);
 
@@ -167,36 +119,15 @@ std::unique_ptr<SLArEventChargePixel>& SLArEventTileUniquePtr::RegisterChargeHit
   }
   else {
     //printf("SLArEventTile::RegisterChargeHit(%i): creating new pixel hit collection.\n", pixID);
-    std::unique_ptr<SLArEventChargePixel> pixEv = std::make_unique<SLArEventChargePixel>(pixID, qhit); 
-    pixEv->SetBacktrackerRecordSize( fChargeBacktrackerRecordSize ); 
-    fPixelHits.insert(std::make_pair(pixID, std::move(pixEv)));
+    fPixelHits.insert(std::make_pair(pixID, new SLArEventChargePixel(pixID, qhit)));
+    //printf("SLArEventTile::RegisterChargeHit(%i): setting backtracker size to %u.\n", pixID, fChargeBacktrackerRecordSize);
+    fPixelHits[pixID]->SetBacktrackerRecordSize( fChargeBacktrackerRecordSize ); 
     return fPixelHits[pixID];
   }
 
 }
 
-template<>
-SLArEventChargePixel*& SLArEventTilePtr::RegisterChargeHit(const int& pixID, const SLArEventChargeHit& qhit) {
-  
-  auto it = fPixelHits.find(pixID);
-
-  if (it != fPixelHits.end()) {
-    //printf("SLArEventTile::RegisterChargeHit(%i): pixel %i already hit.\n", pixID, pixID);
-    it->second->RegisterHit(qhit); 
-    return it->second;
-  }
-  else {
-    //printf("SLArEventTile::RegisterChargeHit(%i): creating new pixel hit collection.\n", pixID);
-    SLArEventChargePixel* pixEv = new SLArEventChargePixel(pixID, qhit); 
-    pixEv->SetBacktrackerRecordSize( fChargeBacktrackerRecordSize ); 
-    fPixelHits.insert(std::make_pair(pixID, std::move(pixEv)));
-    return fPixelHits[pixID];
-  }
-
-}
-
-template<class P>
-double SLArEventTile<P>::GetPixelHits() const {
+double SLArEventTile::GetPixelHits() const {
   double nhits = 0.;
   for (const auto &pixel : fPixelHits) {
     nhits += pixel.second->GetNhits(); 

--- a/G4SOLAr/src/event/SLArEventTrajectory.cc
+++ b/G4SOLAr/src/event/SLArEventTrajectory.cc
@@ -5,6 +5,7 @@
  */
 
 #include "event/SLArEventTrajectory.hh"
+#include <cstdio>
 
 ClassImp(SLArEventTrajectory)
 
@@ -16,28 +17,38 @@ SLArEventTrajectory::SLArEventTrajectory() :
   fInitKineticEnergy(0.), fTrackLength(0.), fTime(0.), fWeight(1.),
   fInitMomentum(TVector3(0,0,0)), 
   fTotalEdep(0.), fTotalNph(0.), fTotalNel(0.)
-{}
-
-SLArEventTrajectory::SLArEventTrajectory(SLArEventTrajectory* trj) 
-  : TObject(*trj)
 {
-  fParticleName = trj->fParticleName; 
-  fCreatorProcess = trj->fCreatorProcess; 
-  fEndProcess = trj->fEndProcess; 
-  fPDGID = trj->fPDGID; 
-  fTrackID = trj->fTrackID; 
-  fParentID = trj->fParentID; 
-  fInitKineticEnergy = trj->fInitKineticEnergy; 
-  fTrackLength = trj->fTrackLength; 
-  fTime = trj->fTime; 
-  fWeight = trj->fWeight;
-  fInitMomentum = trj->fInitMomentum; 
-  fTotalEdep = trj->fTotalEdep; 
-  fTotalNph = trj->fTotalNph; 
-  fTotalNel = trj->fTotalNel; 
+  //fTrjPoints.reserve(500);
+}
 
-  fTrjPoints.resize(trj->fTrjPoints.size()); 
-  fTrjPoints.assign(trj->fTrjPoints.begin(), trj->fTrjPoints.end()); 
+SLArEventTrajectory::SLArEventTrajectory(const SLArEventTrajectory& trj) 
+  : TObject(trj)
+{
+  //printf("Creating new SLArEventTrajectory with copy costructor\n");
+  //printf("trk ID %i, PDG ID %i - trj size %lu\n", 
+      //trj.GetTrackID(), 
+      //trj.GetPDGID(), 
+      //trj.fTrjPoints.size());
+
+  fParticleName = trj.fParticleName; 
+  fCreatorProcess = trj.fCreatorProcess; 
+  fEndProcess = trj.fEndProcess; 
+  fPDGID = trj.fPDGID; 
+  fTrackID = trj.fTrackID; 
+  fParentID = trj.fParentID; 
+  fInitKineticEnergy = trj.fInitKineticEnergy; 
+  fTrackLength = trj.fTrackLength; 
+  fTime = trj.fTime; 
+  fWeight = trj.fWeight;
+  fInitMomentum = trj.fInitMomentum; 
+  fTotalEdep = trj.fTotalEdep; 
+  fTotalNph = trj.fTotalNph; 
+  fTotalNel = trj.fTotalNel; 
+
+  for (const trj_point& pt : trj.fTrjPoints) {
+    fTrjPoints.push_back( pt );
+  }
+  
 }
 
 SLArEventTrajectory::~SLArEventTrajectory()

--- a/G4SOLAr/src/event/SLArMCEvent.cc
+++ b/G4SOLAr/src/event/SLArMCEvent.cc
@@ -24,15 +24,15 @@ SLArMCEvent::SLArMCEvent(const SLArMCEvent& ev) : TObject(ev)
   fDirection = ev.fDirection;
 
   for (const auto& p : ev.fSLArPrimary) {
-    fSLArPrimary.push_back( new SLArMCPrimaryInfo(*p) );
+    fSLArPrimary.push_back( SLArMCPrimaryInfo(p) );
   }
 
   for (const auto& itr : ev.fEvAnode) {
-    fEvAnode[itr.first] = new SLArEventAnode(*itr.second);
+    fEvAnode[itr.first] = SLArEventAnode(itr.second);
   }
 
   for (const auto & itr : ev.fEvSuperCellArray) {
-    fEvSuperCellArray[itr.first] = new SLArEventSuperCellArray(*itr.second);
+    fEvSuperCellArray[itr.first] = SLArEventSuperCellArray(itr.second);
   }
 }
 
@@ -40,20 +40,20 @@ SLArMCEvent::~SLArMCEvent()
 {
   std::cerr << "Deleting SLArMCEvent..." << std::endl;
   for (auto &evAnode : fEvAnode) {
-    evAnode.second->ResetHits();
-    delete evAnode.second;
+    evAnode.second.ResetHits();
+    //delete evAnode.second;
   }
   fEvAnode.clear(); 
 
   for ( auto &scArray : fEvSuperCellArray ) {
-    scArray.second->ResetHits();
-    delete scArray.second;
+    scArray.second.ResetHits();
+    //delete scArray.second;
   }
   fEvSuperCellArray.clear(); 
 
-  for ( auto &p : fSLArPrimary) {
-    delete p; 
-  }
+  //for ( auto &p : fSLArPrimary) {
+    //delete p; 
+  //}
   fSLArPrimary.clear();
   std::cerr << "~SLArMCEvent DONE" << std::endl;
 }
@@ -62,8 +62,8 @@ SLArMCEvent::~SLArMCEvent()
 int SLArMCEvent::ConfigAnode(std::map<int, SLArCfgAnode*> anodeCfg)
 {
   for (const auto& anode : anodeCfg) {
-    fEvAnode.insert(std::make_pair(anode.first, new SLArEventAnode(anode.second)));
-    fEvAnode[anode.first]->SetID(anode.second->GetIdx());
+    fEvAnode.insert(std::make_pair(anode.first, SLArEventAnode(anode.second)));
+    fEvAnode[anode.first].SetID(anode.second->GetIdx());
   }
 
   return fEvAnode.size();
@@ -78,16 +78,16 @@ int SLArMCEvent::ConfigSuperCellSystem(SLArCfgSystemSuperCell* supercellSysCfg)
       continue;
     }
 
-    fEvSuperCellArray.insert(std::make_pair(scArray.first, new SLArEventSuperCellArray(scArray.second)));
-    fEvSuperCellArray[scArray.first]->ConfigSystem(scArray.second);
+    fEvSuperCellArray.insert(std::make_pair(scArray.first, SLArEventSuperCellArray(scArray.second)));
+    fEvSuperCellArray[scArray.first].ConfigSystem(scArray.second);
   }
 
   return fEvSuperCellArray.size();
 }
 
-SLArEventAnode* SLArMCEvent::GetEventAnodeByID(const int& id) {
+SLArEventAnode& SLArMCEvent::GetEventAnodeByID(const int& id) {
   for (auto &anode : fEvAnode) {
-    if (anode.second->GetID() == id) {return anode.second;}
+    if (anode.second.GetID() == id) {return anode.second;}
   }
 
   throw 4;
@@ -102,16 +102,16 @@ int SLArMCEvent::SetEvNumber(int nEv)
 void SLArMCEvent::Reset()
 {
   for (auto &anode : fEvAnode) {
-    anode.second->ResetHits();
+    anode.second.ResetHits();
   }
 
   for (auto &scArray : fEvSuperCellArray) {
-    scArray.second->ResetHits(); 
+    scArray.second.ResetHits(); 
   }
 
-  for (auto &p : fSLArPrimary) {
-    delete p;
-  }
+  //for (auto &p : fSLArPrimary) {
+    //delete p;
+  //}
   fSLArPrimary.clear(); 
 
   fDirection = {0, 0, 1};
@@ -135,7 +135,7 @@ void SLArMCEvent::SetDirection(double px, double py, double pz) {
 bool SLArMCEvent::CheckIfPrimary(int trkId) const {
   bool is_primary = false; 
   for (const auto &p : fSLArPrimary) {
-    if (trkId == p->GetTrackID()) {
+    if (trkId == p.GetTrackID()) {
       is_primary = true; 
       break;
     }
@@ -143,7 +143,7 @@ bool SLArMCEvent::CheckIfPrimary(int trkId) const {
   return is_primary; 
 }
 
-size_t SLArMCEvent::RegisterPrimary(SLArMCPrimaryInfo* p) {
+size_t SLArMCEvent::RegisterPrimary(SLArMCPrimaryInfo& p) {
   fSLArPrimary.push_back( std::move(p) );
   return fSLArPrimary.size();
 }

--- a/G4SOLAr/src/event/SLArMCEvent.cc
+++ b/G4SOLAr/src/event/SLArMCEvent.cc
@@ -18,13 +18,7 @@ template<class P, class A, class X>
 SLArMCEvent<P,A,X>::SLArMCEvent() : 
   fEvNumber(0), fDirection{0, 0, 0}
 {
-  printf("SLArMCEvent constructor:\n");
-
-  printf("MCPrymary type: %s\n", typeid(P).name());
-  printf("EvAnode type: %s\n", typeid(A).name());
-  printf("EvSuperCell type: %s\n", typeid(X).name());
-  getchar();
-  fSLArPrimary.reserve(50);
+   fSLArPrimary.reserve(50);
 }
 
 template<>
@@ -126,14 +120,10 @@ int SLArMCEventPtr::ConfigAnode(std::map<int, SLArCfgAnode*> anodeCfg)
 {
   for (const auto& anode : anodeCfg) {
     fEvAnode.insert(std::make_pair(anode.first, new SLArEventAnodePtr(anode.second)));
-    fEvAnode[anode.first]->SetID(anode.first);
+    fEvAnode[anode.first]->SetID(anode.second->GetIdx());
     //evAnode->ConfigSystem(anode.second); 
   }
 
-  std::cout << "fEvAnode type is " << typeid(fEvAnode).name() << std::endl;
-
-  getchar();
-  
   return fEvAnode.size();
 }
 

--- a/G4SOLAr/src/event/SLArMCEvent.cc
+++ b/G4SOLAr/src/event/SLArMCEvent.cc
@@ -7,45 +7,138 @@
 #include "SLArAnalysisManager.hh"
 #include "event/SLArMCEvent.hh"
 #include "TRandom3.h"
-ClassImp(SLArMCEvent)
+#include <cstdio>
+#include <typeinfo>
+templateClassImp(SLArMCEvent)
 
-SLArMCEvent::SLArMCEvent() : 
+template class SLArMCEvent<SLArMCPrimaryInfoPtr*, SLArEventAnodePtr*, SLArEventSuperCellArrayPtr*>;
+template class SLArMCEvent<std::unique_ptr<SLArMCPrimaryInfoUniquePtr>, std::unique_ptr<SLArEventAnodeUniquePtr>, std::unique_ptr<SLArEventSuperCellArrayUniquePtr>>;
+
+template<class P, class A, class X>
+SLArMCEvent<P,A,X>::SLArMCEvent() : 
   fEvNumber(0), fDirection{0, 0, 0}
-{}
+{
+  printf("SLArMCEvent constructor:\n");
 
-SLArMCEvent::~SLArMCEvent()
+  printf("MCPrymary type: %s\n", typeid(P).name());
+  printf("EvAnode type: %s\n", typeid(A).name());
+  printf("EvSuperCell type: %s\n", typeid(X).name());
+  getchar();
+  fSLArPrimary.reserve(50);
+}
+
+template<>
+SLArMCEventPtr::SLArMCEvent(const SLArMCEventPtr& ev) : TObject(ev)
+{
+  fEvNumber = ev.fEvNumber;
+  fDirection = ev.fDirection;
+
+  for (const auto& p : ev.fSLArPrimary) {
+    fSLArPrimary.push_back( new SLArMCPrimaryInfoPtr(*p) );
+  }
+
+  for (const auto& itr : ev.fEvAnode) {
+    fEvAnode[itr.first] = new SLArEventAnodePtr(*itr.second);
+  }
+
+  for (const auto & itr : ev.fEvSuperCellArray) {
+    fEvSuperCellArray[itr.first] = new SLArEventSuperCellArrayPtr(*itr.second);
+  }
+}
+
+template<>
+SLArMCEventUniquePtr::SLArMCEvent(const SLArMCEventUniquePtr& ev) : TObject(ev)
+{
+  fEvNumber = ev.fEvNumber;
+  fDirection = ev.fDirection;
+
+  for (const auto& p : ev.fSLArPrimary) {
+    fSLArPrimary.push_back( std::make_unique<SLArMCPrimaryInfoUniquePtr>(*p) );
+  }
+
+  for (const auto& itr : ev.fEvAnode) {
+    fEvAnode[itr.first] = std::make_unique<SLArEventAnodeUniquePtr>(*itr.second);
+  }
+
+  for (const auto & itr : ev.fEvSuperCellArray) {
+    fEvSuperCellArray[itr.first] = std::make_unique<SLArEventSuperCellArrayUniquePtr>(*itr.second);
+  }
+}
+
+
+
+template<>
+SLArMCEventPtr::~SLArMCEvent()
 {
   std::cerr << "Deleting SLArMCEvent..." << std::endl;
   for (auto &evAnode : fEvAnode) {
-    if (evAnode.second) delete evAnode.second;
+    evAnode.second->ResetHits();
+    delete evAnode.second;
   }
   fEvAnode.clear(); 
 
   for ( auto &scArray : fEvSuperCellArray ) {
-    if (scArray.second) delete scArray.second;
+    scArray.second->ResetHits();
+    delete scArray.second;
   }
   fEvSuperCellArray.clear(); 
 
-  for (auto &p : fSLArPrimary) {
-    delete p; p = nullptr; 
+  for (auto &primary : fSLArPrimary) {
+    delete primary;
   }
   fSLArPrimary.clear();
   std::cerr << "~SLArMCEvent DONE" << std::endl;
 }
 
-int SLArMCEvent::ConfigAnode(std::map<int, SLArCfgAnode*> anodeCfg)
+template<>
+SLArMCEventUniquePtr::~SLArMCEvent()
+{
+  std::cerr << "Deleting SLArMCEvent..." << std::endl;
+  for (auto &evAnode : fEvAnode) {
+    evAnode.second.get()->ResetHits();
+  }
+  fEvAnode.clear(); 
+
+  for ( auto &scArray : fEvSuperCellArray ) {
+    scArray.second.get()->ResetHits();
+  }
+  fEvSuperCellArray.clear(); 
+
+  fSLArPrimary.clear();
+  std::cerr << "~SLArMCEvent DONE" << std::endl;
+}
+
+template<>
+int SLArMCEventUniquePtr::ConfigAnode(std::map<int, SLArCfgAnode*> anodeCfg)
 {
   for (const auto& anode : anodeCfg) {
-    SLArEventAnode* evAnode = new SLArEventAnode(anode.second); 
-    evAnode->SetID(anode.second->GetIdx()); 
-    //evAnode->ConfigSystem(anode.second); 
-    fEvAnode.insert(std::make_pair(anode.first, evAnode)); 
+    fEvAnode.insert(std::make_pair(anode.first, std::make_unique<SLArEventAnodeUniquePtr>(anode.second)));
+    fEvAnode[anode.first]->SetID(anode.second->GetIdx());
   }
+  std::cout << "fEvAnode type is " << typeid(fEvAnode).name() << std::endl;
+
+  getchar();  
+  return fEvAnode.size();
+}
+
+template<>
+int SLArMCEventPtr::ConfigAnode(std::map<int, SLArCfgAnode*> anodeCfg)
+{
+  for (const auto& anode : anodeCfg) {
+    fEvAnode.insert(std::make_pair(anode.first, new SLArEventAnodePtr(anode.second)));
+    fEvAnode[anode.first]->SetID(anode.first);
+    //evAnode->ConfigSystem(anode.second); 
+  }
+
+  std::cout << "fEvAnode type is " << typeid(fEvAnode).name() << std::endl;
+
+  getchar();
   
   return fEvAnode.size();
 }
 
-int SLArMCEvent::ConfigSuperCellSystem(SLArCfgSystemSuperCell* supercellSysCfg)
+template<>
+int SLArMCEventUniquePtr::ConfigSuperCellSystem(SLArCfgSystemSuperCell* supercellSysCfg)
 {
   for (const auto& scArray : supercellSysCfg->GetMap()) {
     if (fEvSuperCellArray.count(scArray.first)) {
@@ -54,47 +147,95 @@ int SLArMCEvent::ConfigSuperCellSystem(SLArCfgSystemSuperCell* supercellSysCfg)
       continue;
     }
 
-    SLArEventSuperCellArray* evSCArray = new SLArEventSuperCellArray(scArray.second); 
-    evSCArray->ConfigSystem(scArray.second); 
-    fEvSuperCellArray.insert(std::make_pair(scArray.first, evSCArray));
+    fEvSuperCellArray.insert(std::make_pair(scArray.first, std::make_unique<SLArEventSuperCellArrayUniquePtr>(scArray.second)));
+    fEvSuperCellArray[scArray.first]->ConfigSystem(scArray.second);
   }
 
   return fEvSuperCellArray.size();
 }
 
-SLArEventAnode* SLArMCEvent::GetEventAnodeByID(int id) {
+template<>
+int SLArMCEventPtr::ConfigSuperCellSystem(SLArCfgSystemSuperCell* supercellSysCfg)
+{
+  for (const auto& scArray : supercellSysCfg->GetMap()) {
+    if (fEvSuperCellArray.count(scArray.first)) {
+      printf("SLArMCEvent::ConfigSuperCellSystem() WARNING: "); 
+      printf("SuperCelll array with index %i is aleady stored in the MCEvent. Skipping.\n", scArray.first);
+      continue;
+    }
+
+    fEvSuperCellArray.insert(std::make_pair(scArray.first, new SLArEventSuperCellArrayPtr(scArray.second)));
+    fEvSuperCellArray[scArray.first]->ConfigSystem(scArray.second);
+  }
+
+  return fEvSuperCellArray.size();
+}
+
+template<>
+std::unique_ptr<SLArEventAnodeUniquePtr>& SLArMCEventUniquePtr::GetEventAnodeByID(const int& id) {
   for (auto &anode : fEvAnode) {
     if (anode.second->GetID() == id) {return anode.second;}
   }
 
-  return nullptr;
+  throw 4;
 }
 
-int SLArMCEvent::SetEvNumber(int nEv)
+template<>
+SLArEventAnodePtr*& SLArMCEventPtr::GetEventAnodeByID(const int& id) {
+  for (auto &anode : fEvAnode) {
+    if (anode.second->GetID() == id) {return anode.second;}
+  }
+
+  throw 4;
+}
+
+
+template<class P, class A, class X>
+int SLArMCEvent<P,A,X>::SetEvNumber(int nEv)
 {
   fEvNumber = nEv;
   return fEvNumber;
 }
 
-void SLArMCEvent::Reset()
+template<>
+void SLArMCEventUniquePtr::Reset()
 {
   for (auto &anode : fEvAnode) {
-    if (anode.second) anode.second->ResetHits();
+    anode.second->ResetHits();
   }
 
   for (auto &scArray : fEvSuperCellArray) {
-    if (scArray.second) scArray.second->ResetHits(); 
+    scArray.second->ResetHits(); 
   }
 
-  for (auto &p : fSLArPrimary) {
-    delete p; p = nullptr; 
-  }
   fSLArPrimary.clear(); 
+
   fDirection = {0, 0, 1};
   fEvNumber = -1;
 }
 
-void SLArMCEvent::SetDirection(double* dir) {
+template<>
+void SLArMCEventPtr::Reset()
+{
+  for (auto &anode : fEvAnode) {
+    anode.second->ResetHits();
+  }
+
+  for (auto &scArray : fEvSuperCellArray) {
+    scArray.second->ResetHits(); 
+  }
+
+  for (auto &p : fSLArPrimary) {
+    delete p; 
+  }
+  fSLArPrimary.clear(); 
+
+  fDirection = {0, 0, 1};
+  fEvNumber = -1;
+}
+
+template<class P, class A, class X>
+void SLArMCEvent<P,A,X>::SetDirection(double* dir) {
   if (dir) {
     fDirection.at(0) = dir[0];  
     fDirection.at(1) = dir[1];  
@@ -102,13 +243,15 @@ void SLArMCEvent::SetDirection(double* dir) {
   } 
 }
 
-void SLArMCEvent::SetDirection(double px, double py, double pz) {
+template<class P, class A, class X>
+void SLArMCEvent<P,A,X>::SetDirection(double px, double py, double pz) {
     fDirection.at(0) = px;  
     fDirection.at(1) = py;  
     fDirection.at(2) = pz;  
 }
 
-bool SLArMCEvent::CheckIfPrimary(int trkId) {
+template<class P, class A, class X>
+bool SLArMCEvent<P,A,X>::CheckIfPrimary(int trkId) const {
   bool is_primary = false; 
   for (const auto &p : fSLArPrimary) {
     if (trkId == p->GetTrackID()) {
@@ -118,3 +261,16 @@ bool SLArMCEvent::CheckIfPrimary(int trkId) {
   }
   return is_primary; 
 }
+
+template<>
+size_t SLArMCEventUniquePtr::RegisterPrimary(std::unique_ptr<SLArMCPrimaryInfoUniquePtr> p) {
+  fSLArPrimary.push_back( std::move(p) );
+  return fSLArPrimary.size();
+}
+
+template<>
+size_t SLArMCEventPtr::RegisterPrimary(SLArMCPrimaryInfoPtr* p) {
+  fSLArPrimary.push_back( std::move(p) );
+  return fSLArPrimary.size();
+}
+

--- a/G4SOLAr/src/event/SLArMCEvent.cc
+++ b/G4SOLAr/src/event/SLArMCEvent.cc
@@ -103,6 +103,17 @@ SLArMCEventUniquePtr::~SLArMCEvent()
 }
 
 template<>
+template<>
+void SLArEventTileUniquePtr::SoftCopy(SLArEventTilePtr& record) const
+{
+  record.SoftResetHits(); 
+  Copy(record); 
+  for (const auto &pix : fPixelHits) {
+    record.GetPixelEvents()[pix.first] = pix.second.get();
+  }
+}
+
+template<>
 int SLArMCEventUniquePtr::ConfigAnode(std::map<int, SLArCfgAnode*> anodeCfg)
 {
   for (const auto& anode : anodeCfg) {

--- a/G4SOLAr/src/event/SLArMCPrimaryInfo.cc
+++ b/G4SOLAr/src/event/SLArMCPrimaryInfo.cc
@@ -63,6 +63,27 @@ SLArMCPrimaryInfoPtr::~SLArMCPrimaryInfo() {
   fTrajectories.clear();
 }
 
+template<>
+template<>
+void SLArMCPrimaryInfoUniquePtr::SoftCopy(SLArMCPrimaryInfoPtr& record) const {
+  record.SoftResetParticle();
+  record.SetName(fName);
+  record.SetID(fID);
+  record.SetTrackID(fTrkID);
+  record.SetMomentum(fMomentum[0], fMomentum[1], fMomentum[2], fEnergy);
+  record.SetTotalEdep(fTotalEdep);
+  record.SetTotalLArEdep(fTotalLArEdep);
+  record.SetTotalCerenkovPhotons(fTotalCerenkovPhotons);
+  record.SetPosition(fVertex[0], fVertex[1], fVertex[2], fTime);
+
+  record.GetTrajectories().reserve( fTrajectories.size() ); 
+  for (const auto& t : fTrajectories) {
+    record.GetTrajectories().push_back(t.get());
+  }
+
+  return;
+}
+
 template<class T>
 void SLArMCPrimaryInfo<T>::SetPosition(const double& x, const double& y,
                                     const double& z, const double& t)
@@ -105,6 +126,24 @@ void SLArMCPrimaryInfoUniquePtr::ResetParticle()
   std::fill(fMomentum.begin(), fMomentum.end(), 0.); 
 }
 
+
+template<class T>
+void SLArMCPrimaryInfo<T>::SoftResetParticle()
+{
+  fID           = 0;
+  fTrkID        = 0; 
+  fName         = "noName";
+  fEnergy       = 0.;
+  fTime         = 0.;
+  fTotalEdep    = 0.;
+  fTotalLArEdep = 0.;
+  fTotalScintPhotons = 0; 
+  fTotalCerenkovPhotons = 0; 
+
+  fTrajectories.clear();
+  std::fill(fVertex.begin(), fVertex.end(), 0.); 
+  std::fill(fMomentum.begin(), fMomentum.end(), 0.); 
+}
 
 template<>
 void SLArMCPrimaryInfoPtr::ResetParticle()

--- a/G4SOLAr/src/event/SLArMCPrimaryInfo.cc
+++ b/G4SOLAr/src/event/SLArMCPrimaryInfo.cc
@@ -10,13 +10,9 @@
 #include <memory>
 #include "event/SLArMCPrimaryInfo.hh"
 
-templateClassImp(SLArMCPrimaryInfo)
+ClassImp(SLArMCPrimaryInfo)
 
-template class SLArMCPrimaryInfo<SLArEventTrajectory*>;
-template class SLArMCPrimaryInfo<std::unique_ptr<SLArEventTrajectory>>;
-
-template<class T>
-SLArMCPrimaryInfo<T>::SLArMCPrimaryInfo() : 
+SLArMCPrimaryInfo::SLArMCPrimaryInfo() : 
   fID(0), fTrkID(0), fName("noParticle"), fEnergy(0.),
   fTotalEdep(0.), fTotalLArEdep(0), fTotalScintPhotons(0), fTotalCerenkovPhotons(0),
   fVertex(3, 0.), fMomentum(3, 0.)
@@ -24,8 +20,7 @@ SLArMCPrimaryInfo<T>::SLArMCPrimaryInfo() :
   fTrajectories.reserve(100);
 }
 
-template<>
-SLArMCPrimaryInfoUniquePtr::SLArMCPrimaryInfo(const SLArMCPrimaryInfo& p) 
+SLArMCPrimaryInfo::SLArMCPrimaryInfo(const SLArMCPrimaryInfo& p) 
   : TNamed(p), 
     fID(p.fID), fTrkID(p.fTrkID), fEnergy(p.fEnergy), 
     fTotalEdep(p.fTotalEdep), fTotalLArEdep(p.fTotalLArEdep), 
@@ -33,59 +28,15 @@ SLArMCPrimaryInfoUniquePtr::SLArMCPrimaryInfo(const SLArMCPrimaryInfo& p)
     fVertex(p.fVertex), fMomentum(p.fMomentum) 
 {
   for (const auto& t : p.fTrajectories) {
-    fTrajectories.push_back(std::make_unique<SLArEventTrajectory>(*t)); 
+    fTrajectories.push_back( std::make_unique<SLArEventTrajectory>(*t) ); 
   }
 }
 
-template<>
-SLArMCPrimaryInfoPtr::SLArMCPrimaryInfo(const SLArMCPrimaryInfo& p) 
-  : TNamed(p), 
-    fID(p.fID), fTrkID(p.fTrkID), fEnergy(p.fEnergy), 
-    fTotalEdep(p.fTotalEdep), fTotalLArEdep(p.fTotalLArEdep), 
-    fTotalScintPhotons(p.fTotalScintPhotons), fTotalCerenkovPhotons(p.fTotalCerenkovPhotons),
-    fVertex(p.fVertex), fMomentum(p.fMomentum) 
-{
-  for (const auto& t : p.fTrajectories) {
-    fTrajectories.push_back(new SLArEventTrajectory(*t)); 
-  }
-}
-
-template<>
-SLArMCPrimaryInfoUniquePtr::~SLArMCPrimaryInfo() {
+SLArMCPrimaryInfo::~SLArMCPrimaryInfo() {
   fTrajectories.clear();
 }
 
-template<>
-SLArMCPrimaryInfoPtr::~SLArMCPrimaryInfo() {
-  for (auto &t : fTrajectories) {
-    delete t;
-  }
-  fTrajectories.clear();
-}
-
-template<>
-template<>
-void SLArMCPrimaryInfoUniquePtr::SoftCopy(SLArMCPrimaryInfoPtr& record) const {
-  record.SoftResetParticle();
-  record.SetName(fName);
-  record.SetID(fID);
-  record.SetTrackID(fTrkID);
-  record.SetMomentum(fMomentum[0], fMomentum[1], fMomentum[2], fEnergy);
-  record.SetTotalEdep(fTotalEdep);
-  record.SetTotalLArEdep(fTotalLArEdep);
-  record.SetTotalCerenkovPhotons(fTotalCerenkovPhotons);
-  record.SetPosition(fVertex[0], fVertex[1], fVertex[2], fTime);
-
-  record.GetTrajectories().reserve( fTrajectories.size() ); 
-  for (const auto& t : fTrajectories) {
-    record.GetTrajectories().push_back(t.get());
-  }
-
-  return;
-}
-
-template<class T>
-void SLArMCPrimaryInfo<T>::SetPosition(const double& x, const double& y,
+void SLArMCPrimaryInfo::SetPosition(const double& x, const double& y,
                                     const double& z, const double& t)
 {
   fVertex[0] = x;
@@ -96,8 +47,7 @@ void SLArMCPrimaryInfo<T>::SetPosition(const double& x, const double& y,
   fTotalScintPhotons = 0; 
 }
 
-template<class T>
-void SLArMCPrimaryInfo<T>::SetMomentum(const double& px, const double& py, const double& pz, const double& ene)
+void SLArMCPrimaryInfo::SetMomentum(const double& px, const double& py, const double& pz, const double& ene)
 {
   fMomentum[0] = px;
   fMomentum[1] = py;
@@ -105,8 +55,7 @@ void SLArMCPrimaryInfo<T>::SetMomentum(const double& px, const double& py, const
   fEnergy   = ene;
 }
 
-template<>
-void SLArMCPrimaryInfoUniquePtr::ResetParticle()
+void SLArMCPrimaryInfo::ResetParticle()
 {
   fID           = 0;
   fTrkID        = 0; 
@@ -127,47 +76,7 @@ void SLArMCPrimaryInfoUniquePtr::ResetParticle()
 }
 
 
-template<class T>
-void SLArMCPrimaryInfo<T>::SoftResetParticle()
-{
-  fID           = 0;
-  fTrkID        = 0; 
-  fName         = "noName";
-  fEnergy       = 0.;
-  fTime         = 0.;
-  fTotalEdep    = 0.;
-  fTotalLArEdep = 0.;
-  fTotalScintPhotons = 0; 
-  fTotalCerenkovPhotons = 0; 
-
-  fTrajectories.clear();
-  std::fill(fVertex.begin(), fVertex.end(), 0.); 
-  std::fill(fMomentum.begin(), fMomentum.end(), 0.); 
-}
-
-template<>
-void SLArMCPrimaryInfoPtr::ResetParticle()
-{
-  fID           = 0;
-  fTrkID        = 0; 
-  fName         = "noName";
-  fEnergy       = 0.;
-  fTime         = 0.;
-  fTotalEdep    = 0.;
-  fTotalLArEdep = 0.;
-  fTotalScintPhotons = 0; 
-  fTotalCerenkovPhotons = 0; 
-
-  for (auto &t :fTrajectories) {
-    delete t;
-  }
-  fTrajectories.clear();
-  std::fill(fVertex.begin(), fVertex.end(), 0.); 
-  std::fill(fMomentum.begin(), fMomentum.end(), 0.); 
-}
-
-template<class T>
-void SLArMCPrimaryInfo<T>::PrintParticle() const
+void SLArMCPrimaryInfo::PrintParticle() const
 {
   std::cout << "SLAr Primary Info: " << std::endl;
   std::cout << "Particle:" << fName << ", id: " << fID <<", trk id: " << fTrkID << std::endl;
@@ -180,8 +89,7 @@ void SLArMCPrimaryInfo<T>::PrintParticle() const
                            << fMomentum[2]<< std::endl;
 }
 
-template<class T>
-int SLArMCPrimaryInfo<T>::RegisterTrajectory(T trj)
+int SLArMCPrimaryInfo::RegisterTrajectory(std::unique_ptr<SLArEventTrajectory> trj)
 {
   fTotalEdep += trj->GetTotalEdep(); 
   //fTrajectories.push_back(trj);

--- a/G4SOLAr/src/physics/SLArElectronDrift.cc
+++ b/G4SOLAr/src/physics/SLArElectronDrift.cc
@@ -94,11 +94,12 @@ void SLArElectronDrift::PrintProperties() {
   return;
 }
 
+template<class A>
 void SLArElectronDrift::Drift(const int& n, const int& trkId,
     const G4ThreeVector& pos, 
     const double time, 
     SLArCfgAnode* anodeCfg, 
-    SLArEventAnode* anodeEv) 
+    A anodeEv) 
 {
   auto ana_mngr = SLArAnalysisManager::Instance();
   auto bkt_mngr = ana_mngr->GetBacktrackerManager( backtracker:: kCharge );
@@ -113,12 +114,12 @@ void SLArElectronDrift::Drift(const int& n, const int& trkId,
   G4ThreeVector anodePos = 
     G4ThreeVector(anodeCfg->GetPhysX(), anodeCfg->GetPhysY(), anodeCfg->GetPhysZ()); 
 
-  auto pixID = anodeCfg->FindPixel( pos.dot(anodeXaxis), pos.dot(anodeYaxis) ); 
+  //auto pixID_tmp = anodeCfg->GetPixelCoord( pos.dot(anodeXaxis), pos.dot(anodeYaxis) ); 
   //#ifdef SLAR_DEBUG
   //printf("%i electrons at [%.0f, %0.f, %0.f] mm, t = %g ns\n", 
   //n, pos.x(), pos.y(), pos.z(), time);
   //printf("axis projection: [%.0f, %.0f]\n", pos.dot(anodeXaxis), pos.dot(anodeYaxis)); 
-  //printf("pixID[%i, %i, %i]\n", pixID[0], pixID[1], pixID[2]);
+  //printf("pixID[%i, %i, %i]\n", pixID_tmp[0], pixID_tmp[1], pixID_tmp[2]);
   //#endif
 
   // Get anode position and compute drift time
@@ -147,11 +148,12 @@ void SLArElectronDrift::Drift(const int& n, const int& trkId,
   G4RandGauss::shootArray(n_elec_anode, &y_[0], pos.dot(anodeYaxis), diffLengthT); 
   G4RandGauss::shootArray(n_elec_anode, &t_[0], hitTime, diffLengthL/fvDrift); 
 
+  SLArCfgAnode::SLArPixIdxCoord pixID;
   for (G4int i=0; i<n_elec_anode; i++) {
-    pixID = anodeCfg->FindPixel(x_[i], y_[i]); 
+    pixID = anodeCfg->GetPixelCoord(x_[i], y_[i]); 
     if (pixID[0] > 0 && pixID[1] > 0 && pixID[2] > 0 ) {
-      SLArCfgMegaTile* mtile = (SLArCfgMegaTile*)anodeCfg->FindBaseElementInMap(pixID[0]); 
-      SLArCfgReadoutTile* tile = (SLArCfgReadoutTile*)mtile->FindBaseElementInMap(pixID[1]); 
+      SLArCfgMegaTile* mtile = (SLArCfgMegaTile*)anodeCfg->GetBaseElement(pixID[0]); 
+      SLArCfgReadoutTile* tile = (SLArCfgReadoutTile*)mtile->GetBaseElement(pixID[1]); 
       if (!tile) {
         printf("SLArElectronDrift::WARNING Unable to find tile with bin ID %i (%i, %i, %i)\n", 
             pixID[1], pixID[0], pixID[1], pixID[2]);
@@ -159,25 +161,27 @@ void SLArElectronDrift::Drift(const int& n, const int& trkId,
         continue;
       }
 
-      SLArEventMegatile* evMT=nullptr;
-      auto mt_itr = anodeEv->GetMegaTilesMap().find(mtile->GetIdx());
-      if (mt_itr == anodeEv->GetMegaTilesMap().end()) {
-        evMT = anodeEv->CreateEventMegatile(mtile->GetIdx()); 
-      }
-      else {
-        evMT = mt_itr->second;
-      }
-
-      SLArEventTile* evT=nullptr;
-      auto t_itr = evMT->GetTileMap().find(tile->GetIdx()); 
-      if (t_itr == evMT->GetTileMap().end()) {
-        evT = evMT->CreateEventTile(tile->GetIdx()); 
-      }
-      else {
-        evT = t_itr->second;
-      }
       SLArEventChargeHit hit(t_[i], trkId, 0); 
-      auto ev_pixel = evT->RegisterChargeHit(pixID[2], &hit); 
+      auto& evPixel = anodeEv->RegisterChargeHit(pixID, hit); 
+
+      //SLArEventMegatile* evMT=nullptr;
+      //auto mt_itr = anodeEv->GetMegaTilesMap().find(mtile->GetIdx());
+      //if (mt_itr == anodeEv->GetMegaTilesMap().end()) {
+        //evMT = anodeEv->CreateEventMegatile(mtile->GetIdx()); 
+      //}
+      //else {
+        //evMT = mt_itr->second;
+      //}
+
+      //SLArEventTile* evT=nullptr;
+      //auto t_itr = evMT->GetTileMap().find(tile->GetIdx()); 
+      //if (t_itr == evMT->GetTileMap().end()) {
+        //evT = evMT->CreateEventTile(tile->GetIdx()); 
+      //}
+      //else {
+        //evT = t_itr->second;
+      //}
+      //auto ev_pixel = evT->RegisterChargeHit(pixID[2], hit); 
 
       //#ifdef SLAR_DEBUG
       //printf("\tdiff x,y: %.2f - %.2f mm\n", x_[i], y_[i]);
@@ -191,7 +195,7 @@ void SLArElectronDrift::Drift(const int& n, const int& trkId,
       if (bkt_mngr->IsNull()) continue;
 
       auto records = 
-        ev_pixel->GetBacktrackerVector( ev_pixel->ConvertToClock<float>(hit.GetTime()));
+        evPixel->GetBacktrackerVector( evPixel->template ConvertToClock<float>(hit.GetTime()));
 
       for (size_t ib = 0; ib < bkt_mngr->GetBacktrackers().size(); ib++) {
         bkt_mngr->GetBacktrackers().at(ib)->Eval(&hit, 
@@ -200,5 +204,7 @@ void SLArElectronDrift::Drift(const int& n, const int& trkId,
 
     }
   }
-
 }
+
+template void SLArElectronDrift::Drift<SLArEventAnodePtr*&>(const int& n, const int& trkId, const G4ThreeVector& pos, const double time, SLArCfgAnode* anodeCfg, SLArEventAnodePtr*& anodeEv);
+template void SLArElectronDrift::Drift<std::unique_ptr<SLArEventAnodeUniquePtr>&>(const int& n, const int& trkId, const G4ThreeVector& pos, const double time, SLArCfgAnode* anodeCfg, std::unique_ptr<SLArEventAnodeUniquePtr>& anodeEv);

--- a/G4SOLAr/src/physics/SLArElectronDrift.cc
+++ b/G4SOLAr/src/physics/SLArElectronDrift.cc
@@ -94,12 +94,11 @@ void SLArElectronDrift::PrintProperties() {
   return;
 }
 
-template<class A>
 void SLArElectronDrift::Drift(const int& n, const int& trkId,
     const G4ThreeVector& pos, 
     const double time, 
     SLArCfgAnode* anodeCfg, 
-    A anodeEv) 
+    SLArEventAnode* anodeEv) 
 {
   auto ana_mngr = SLArAnalysisManager::Instance();
   auto bkt_mngr = ana_mngr->GetBacktrackerManager( backtracker:: kCharge );
@@ -162,7 +161,7 @@ void SLArElectronDrift::Drift(const int& n, const int& trkId,
       }
 
       SLArEventChargeHit hit(t_[i], trkId, 0); 
-      auto& evPixel = anodeEv->RegisterChargeHit(pixID, hit); 
+      auto evPixel = anodeEv->RegisterChargeHit(pixID, hit); 
 
       //SLArEventMegatile* evMT=nullptr;
       //auto mt_itr = anodeEv->GetMegaTilesMap().find(mtile->GetIdx());
@@ -194,17 +193,14 @@ void SLArElectronDrift::Drift(const int& n, const int& trkId,
 
       if (bkt_mngr->IsNull()) continue;
 
-      auto records = 
-        evPixel->GetBacktrackerVector( evPixel->template ConvertToClock<float>(hit.GetTime()));
+      auto& records = 
+        evPixel->GetBacktrackerVector( evPixel->ConvertToClock<float>(hit.GetTime()));
 
       for (size_t ib = 0; ib < bkt_mngr->GetBacktrackers().size(); ib++) {
         bkt_mngr->GetBacktrackers().at(ib)->Eval(&hit, 
-            &records->GetRecords().at(ib));
+            &records.GetRecords().at(ib));
       }
-
     }
   }
 }
 
-template void SLArElectronDrift::Drift<SLArEventAnodePtr*&>(const int& n, const int& trkId, const G4ThreeVector& pos, const double time, SLArCfgAnode* anodeCfg, SLArEventAnodePtr*& anodeEv);
-template void SLArElectronDrift::Drift<std::unique_ptr<SLArEventAnodeUniquePtr>&>(const int& n, const int& trkId, const G4ThreeVector& pos, const double time, SLArCfgAnode* anodeCfg, std::unique_ptr<SLArEventAnodeUniquePtr>& anodeEv);

--- a/G4SOLAr/src/physics/SLArElectronDrift.cc
+++ b/G4SOLAr/src/physics/SLArElectronDrift.cc
@@ -161,7 +161,7 @@ void SLArElectronDrift::Drift(const int& n, const int& trkId,
       }
 
       SLArEventChargeHit hit(t_[i], trkId, 0); 
-      auto evPixel = anodeEv->RegisterChargeHit(pixID, hit); 
+      auto& evPixel = anodeEv->RegisterChargeHit(pixID, hit); 
 
       //SLArEventMegatile* evMT=nullptr;
       //auto mt_itr = anodeEv->GetMegaTilesMap().find(mtile->GetIdx());
@@ -194,7 +194,7 @@ void SLArElectronDrift::Drift(const int& n, const int& trkId,
       if (bkt_mngr->IsNull()) continue;
 
       auto& records = 
-        evPixel->GetBacktrackerVector( evPixel->ConvertToClock<float>(hit.GetTime()));
+        evPixel.GetBacktrackerVector( evPixel.ConvertToClock<float>(hit.GetTime()));
 
       for (size_t ib = 0; ib < bkt_mngr->GetBacktrackers().size(); ib++) {
         bkt_mngr->GetBacktrackers().at(ib)->Eval(&hit, 

--- a/G4SOLAr/src/physics/SLArIonAndScintModel.cc
+++ b/G4SOLAr/src/physics/SLArIonAndScintModel.cc
@@ -23,12 +23,11 @@ SLArIonAndScintModel::SLArIonAndScintModel(const G4MaterialPropertiesTable* mpt)
   fIonizationDensity = 1.0 / fWion;   
 }
 
-double SLArIonAndScintModel::ComputeIon(const double energy_deposit, const double step_length, const double electric_field) const {
-  const double yield = ComputeIonYield(energy_deposit, step_length, electric_field); 
-  return energy_deposit * yield; 
+Ion_and_Scint_t SLArIonAndScintModel::ComputeIonAndScint(const double& energy_deposit, const double& step_length, const double& electric_field) const {
+  double dEdx = energy_deposit / step_length;
+  Ion_and_Scint_t yield = ComputeIonAndScintYield(dEdx, electric_field); 
+  yield.ion *= energy_deposit;
+  yield.scint *= energy_deposit;
+  return yield; 
 }
 
-double SLArIonAndScintModel::ComputeScint(const double energy_deposit, const double step_length, const double electric_field) const {
-  const double yield = ComputeScintYield(energy_deposit, step_length, electric_field); 
-  return energy_deposit * yield; 
-}

--- a/G4SOLAr/src/physics/SLArScintillation.cc
+++ b/G4SOLAr/src/physics/SLArScintillation.cc
@@ -388,8 +388,6 @@ G4VParticleChange* SLArScintillation::PostStepDoIt(const G4Track& aTrack,
 
   G4double StepWidth = aStep.GetStepLength();
 
-
-
   G4double TotalEnergyDeposit = aStep.GetTotalEnergyDeposit();
   //G4double NonIonizingEnergyDeposit = aStep.GetNonIonizingEnergyDeposit();
 
@@ -435,19 +433,13 @@ G4VParticleChange* SLArScintillation::PostStepDoIt(const G4Track& aTrack,
       //Get yield1,2,3 from the MaterialPropertiesTable - this is a little bit hacky, but it works
       MeanNumberOfPhotons = GetScintillationYieldByParticleType(aTrack, aStep, yield1, yield2, yield3);
       // Set MeanNumberOfPhotons
-      G4double LightYield = ion_and_scint->ComputeScintYield(
+      Ion_and_Scint_t IonAndScintYield = ion_and_scint->ComputeIonAndScintYield(
           TotalEnergyDeposit/CLHEP::MeV,
           StepWidth/CLHEP::cm,electricField_); 
 
-      MeanNumberOfPhotons = LightYield*(TotalEnergyDeposit/CLHEP::MeV);
+      MeanNumberOfPhotons = IonAndScintYield.scint*(TotalEnergyDeposit/CLHEP::MeV);
       // Set MeanNumberOfIonElectrons
-      G4double ChargeYield = ion_and_scint->ComputeIonYield(
-            TotalEnergyDeposit/CLHEP::MeV,
-            StepWidth/CLHEP::cm,
-            electricField_); 
-      MeanNumberOfIonElectrons = ChargeYield*(TotalEnergyDeposit/CLHEP::MeV); 
-
-      //MeanNumberOfPhotons = LightYield->Flat()*TotalEnergyDeposit/CLHEP::MeV; // Example for other implemented light yields
+      MeanNumberOfIonElectrons = IonAndScintYield.ion*(TotalEnergyDeposit/CLHEP::MeV); 
 
 #ifdef SLAR_DEBUG
               G4double PartX= aStep.GetPreStepPoint()->GetPosition().x()/CLHEP::cm;
@@ -462,8 +454,8 @@ G4VParticleChange* SLArScintillation::PostStepDoIt(const G4Track& aTrack,
               G4cout << "TotalEnergyDeposit = " << TotalEnergyDeposit / CLHEP::MeV<< " MeV" << G4endl;
               G4cout << "StepWidth = " << StepWidth / CLHEP::cm << " cm" << G4endl;
               G4cout << "dE/dx = " << (TotalEnergyDeposit / CLHEP::MeV)/(StepWidth / CLHEP::cm) <<" MeV/cm" << G4endl;
-              G4cout << "Light yield = " << LightYield << " ph/MeV" << G4endl; 
-              G4cout << "Charge yield = " << LightYield << " elec/MeV" << G4endl; 
+              G4cout << "Light yield = " << IonAndScintYield.scint << " ph/MeV" << G4endl; 
+              G4cout << "Charge yield = " << IonAndScintYield.ion << " elec/MeV" << G4endl; 
               G4cout << "Electric Field = " << electricField_ << " kV/cm" << G4endl;
               G4cout << "Relative yields = " << yield1 << " " << yield2 << " " << yield3 << G4endl;
 #endif
@@ -480,16 +472,12 @@ G4VParticleChange* SLArScintillation::PostStepDoIt(const G4Track& aTrack,
       ion_and_scint->SetLightYield(
           GetScintillationYieldByParticleType(aTrack, aStep, yield1, yield2, yield3) 
           / (TotalEnergyDeposit/CLHEP::MeV));
-      const double LightYield = ion_and_scint->ComputeScintYield(
+      auto IonAndScintYield = ion_and_scint->ComputeIonAndScintYield(
           TotalEnergyDeposit/CLHEP::MeV,
           StepWidth/CLHEP::cm,
           electricField_);
-      const double IonYield   = ion_and_scint->ComputeIonYield(
-          TotalEnergyDeposit/CLHEP::MeV,
-          StepWidth/CLHEP::cm,
-          electricField_);
-      MeanNumberOfPhotons = LightYield * (TotalEnergyDeposit/CLHEP::MeV); 
-      MeanNumberOfIonElectrons = IonYield * (TotalEnergyDeposit/CLHEP::MeV); 
+      MeanNumberOfPhotons = IonAndScintYield.scint * (TotalEnergyDeposit/CLHEP::MeV); 
+      MeanNumberOfIonElectrons = IonAndScintYield.ion * (TotalEnergyDeposit/CLHEP::MeV); 
     }
 
   }

--- a/SOLArAnalysis/refactor_test_sc.C
+++ b/SOLArAnalysis/refactor_test_sc.C
@@ -121,13 +121,13 @@ void refactor_test_sc(const TString file_path, const int iev)
   h2SCArray.find(30)->second->Draw("col same"); 
 
   //- - - - - - - - - - - - - - - - - - - - - - Access event
-  SLArMCEventPtr* ev = 0; 
+  SLArMCEvent* ev = 0; 
   mc_tree->SetBranchAddress("MCEvent", &ev); 
   mc_tree->GetEntry(iev); 
 
   auto& primaries = ev->GetPrimaries(); 
 
-  const std::map<int, SLArEventAnodePtr*>& andMap = ev->GetEventAnode(); 
+  const std::map<int, SLArEventAnode*>& andMap = ev->GetEventAnode(); 
 
   for (const auto &anode_ : andMap) {
     auto& anode = anode_.second; 
@@ -138,7 +138,7 @@ void refactor_test_sc(const TString file_path, const int iev)
 
     double z_max = 0; 
     printf("ANODE %i:\n", anode->GetID());
-    for (const auto &mt: anode->GetMegaTilesMap()) {
+    for (const auto &mt: anode->GetConstMegaTilesMap()) {
       printf("\tMegatilte %i: %i hits\n", mt.first, mt.second->GetNChargeHits());
       auto h2mt_ = AnodeSysCfg[tpc_id]->ConstructPixHistMap(1, std::vector<int>{mt.first}); 
       h2mt.push_back( h2mt_ ); 
@@ -157,7 +157,7 @@ void refactor_test_sc(const TString file_path, const int iev)
       }
     }
 
-    for (const auto &mt: anode->GetMegaTilesMap()) {
+    for (const auto &mt: anode->GetConstMegaTilesMap()) {
       if (mt.second->GetNPhotonHits() == 0) continue;
       for (auto &t : mt.second->GetConstTileMap()) {
         if (t.second->GetConstHits().empty()) continue;

--- a/SOLArAnalysis/refactor_test_sc.C
+++ b/SOLArAnalysis/refactor_test_sc.C
@@ -37,46 +37,6 @@ void refactor_test_sc(const TString file_path, const int iev)
   AnodeSysCfg.insert( std::make_pair(10, (SLArCfgAnode*)mc_file->Get("AnodeCfg50") ) );
   AnodeSysCfg.insert( std::make_pair(11, (SLArCfgAnode*)mc_file->Get("AnodeCfg51") ) );
 
-/*
- *  std::map<int, TH2Poly*> h2SCArray; 
- *
- *  for (auto &cfgSCArray_ : PDSSysConfig->GetMap()) {
- *    const auto cfgSCArray = cfgSCArray_.second;
- *    printf("SC cfg config: %i - %lu super-cell\n", cfgSCArray_.first, 
- *        cfgSCArray->GetMap().size());
- *    printf("\tposition: [%g, %g, %g] mm\n", 
- *        cfgSCArray->GetPhysX(), cfgSCArray->GetPhysY(), cfgSCArray->GetPhysZ()); 
- *    printf("\tnormal: [%g, %g, %g]\n", 
- *        cfgSCArray->GetNormal().x(), cfgSCArray->GetNormal().y(), cfgSCArray->GetNormal().z() );
- *    printf("\teuler angles: [φ = %g, θ = %g, ψ = %g]\n", 
- *        cfgSCArray->GetPhi()*TMath::RadToDeg(), 
- *        cfgSCArray->GetTheta()*TMath::RadToDeg(), 
- *        cfgSCArray->GetPsi()*TMath::RadToDeg());
- *    cfgSCArray->BuildGShape(); 
- *    auto h2 = cfgSCArray->BuildPolyBinHist(SLArCfgSuperCellArray::kWorld, 25, 25);  
- *    h2SCArray.insert( std::make_pair(cfgSCArray->GetIdx(), h2) ); 
- *  }
- *  printf("\n");
- *
- *  for (const auto& anodeCfg_ : AnodeSysCfg) {
- *    const auto cfgAnode = anodeCfg_.second;
- *    printf("Anode config: %i - %lu mega-tiles\n", cfgAnode->GetIdx(), 
- *        cfgAnode->GetMap().size());
- *    printf("\tposition: [%g, %g, %g] mm\n", 
- *        cfgAnode->GetPhysX(), cfgAnode->GetPhysY(), cfgAnode->GetPhysZ()); 
- *    printf("\tnormal: [%g, %g, %g]\n", 
- *        cfgAnode->GetNormal().x(), cfgAnode->GetNormal().y(), cfgAnode->GetNormal().z() );
- *    printf("\teuler angles: [φ = %g, θ = %g, ψ = %g]\n", 
- *        cfgAnode->GetPhi()*TMath::RadToDeg(), 
- *        cfgAnode->GetTheta()*TMath::RadToDeg(), 
- *        cfgAnode->GetPsi()*TMath::RadToDeg());
- *  }
- *  printf("\n");
- *  
- *  TH2D* h2_30 = new TH2D("sc_top_30", "30 sc top", 50, -1.5e3, 1.5e3, 50, -1200, 1200); 
- *  h2_30->Draw("axis");
- *  h2SCArray.find(30)->second->Draw("col same"); 
- */
   TH1D* hTime = new TH1D("hPhTime", "Photon hit time;Time [ns];Entries", 1000, 0, 5e3); 
 
   TH1D* hBacktracker = new TH1D("hBacktracker", "backtracker: trkID", 1000, 0, 1000 );
@@ -127,9 +87,9 @@ void refactor_test_sc(const TString file_path, const int iev)
 
   auto& primaries = ev->GetPrimaries(); 
 
-  const std::map<int, SLArEventAnode*>& andMap = ev->GetEventAnode(); 
+  const std::map<int, SLArEventAnode>& anodeMap = ev->GetEventAnode(); 
 
-  for (const auto &anode_ : andMap) {
+  for (const auto &anode_ : anodeMap) {
     auto& anode = anode_.second; 
     int tpc_id = anode_.first; 
     auto hAnode = AnodeSysCfg[tpc_id]->GetAnodeMap(0); 
@@ -137,36 +97,36 @@ void refactor_test_sc(const TString file_path, const int iev)
     std::vector<TH2Poly*> h2pix; h2pix.reserve(500); 
 
     double z_max = 0; 
-    printf("ANODE %i:\n", anode->GetID());
-    for (const auto &mt: anode->GetConstMegaTilesMap()) {
-      printf("\tMegatilte %i: %i hits\n", mt.first, mt.second->GetNChargeHits());
+    printf("ANODE %i:\n", anode.GetID());
+    for (const auto &mt: anode.GetConstMegaTilesMap()) {
+      printf("\tMegatilte %i: %i hits\n", mt.first, mt.second.GetNChargeHits());
       auto h2mt_ = AnodeSysCfg[tpc_id]->ConstructPixHistMap(1, std::vector<int>{mt.first}); 
       h2mt.push_back( h2mt_ ); 
-      if (mt.second->GetNChargeHits() == 0) continue;
-      for (auto &t : mt.second->GetConstTileMap()) {
-        printf("\t\tTilte %i: %g hits\n", t.first, t.second->GetNPixelHits());
-        if (t.second->GetPixelHits() == 0 ) continue;
+      if (mt.second.GetNChargeHits() == 0) continue;
+      for (auto &t : mt.second.GetConstTileMap()) {
+        printf("\t\tTilte %i: %g hits\n", t.first, t.second.GetNPixelHits());
+        if (t.second.GetPixelHits() == 0 ) continue;
         auto h2t_ = AnodeSysCfg[tpc_id]->ConstructPixHistMap(2, std::vector<int>{mt.first, t.first}); 
-        for (const auto &p : t.second->GetConstPixelEvents()) {
-          //printf("\t\t\tPixel %i has %i hits\n", p.first, p.second->GetNhits());
-          h2t_->SetBinContent( p.first, p.second->GetNhits() );
-          p.second->PrintHits();
-          if (p.second->GetNhits() > z_max) z_max = p.second->GetNhits(); 
+        for (const auto &p : t.second.GetConstPixelEvents()) {
+          printf("\t\t\tPixel %i has %i hits\n", p.first, p.second.GetNhits());
+          h2t_->SetBinContent( p.first, p.second.GetNhits() );
+          //p.second.PrintHits();
+          if (p.second.GetNhits() > z_max) z_max = p.second.GetNhits(); 
         }
         h2pix.push_back( h2t_ ); 
       }
     }
 
-    for (const auto &mt: anode->GetConstMegaTilesMap()) {
-      if (mt.second->GetNPhotonHits() == 0) continue;
-      for (auto &t : mt.second->GetConstTileMap()) {
-        if (t.second->GetConstHits().empty()) continue;
-        for (const auto &p : t.second->GetConstHits()) {
+    for (const auto &mt: anode.GetConstMegaTilesMap()) {
+      if (mt.second.GetNPhotonHits() == 0) continue;
+      for (auto &t : mt.second.GetConstTileMap()) {
+        if (t.second.GetConstHits().empty()) continue;
+        for (const auto &p : t.second.GetConstHits()) {
           hTime->Fill( p.first, p.second );  
         }
 
-        if (t.second->GetBacktrackerRecordSize() > 0) {
-          for (const auto &backtracker : t.second->GetBacktrackerRecordCollection()) {
+        if (t.second.GetBacktrackerRecordSize() > 0) {
+          for (const auto &backtracker : t.second.GetBacktrackerRecordCollection()) {
             auto records = backtracker.second.GetConstRecords();
             auto recordTrkID = records.at(0);
             for (const auto &trkID : recordTrkID.GetConstCounter()) {
@@ -192,17 +152,17 @@ void refactor_test_sc(const TString file_path, const int iev)
     for (const auto &p : primaries) {
       printf("----------------------------------------\n");
       printf("PRIMARY vertex: %s - K0 = %2f - t = %.2f - vtx [%.1f, %.1f, %.1f]\n", 
-          p->GetParticleName().Data(), p->GetEnergy(), p->GetTime(), 
-          p->GetVertex()[0], p->GetVertex()[1], p->GetVertex()[2]);
-      auto& trajectories = p->GetConstTrajectories(); 
+          p.GetParticleName().Data(), p.GetEnergy(), p.GetTime(), 
+          p.GetVertex()[0], p.GetVertex()[1], p.GetVertex()[2]);
+      auto& trajectories = p.GetConstTrajectories(); 
       for (auto &t : trajectories) {
         auto points = t->GetConstPoints(); 
         auto pdg_particle = pdg->GetParticle(t->GetPDGID()); 
-        //printf("%s [%i]: t = %.2f, K = %.2f - n_scint = %g, n_elec = %g\n", 
-            //t->GetParticleName().Data(), t->GetTrackID(), 
-            //t->GetTime(),
-            //t->GetInitKineticEne(), 
-            //t->GetTotalNph(), t->GetTotalNel());
+        printf("%s [%i]: t = %.2f, K = %.2f - n_scint = %g, n_elec = %g\n", 
+            t->GetParticleName().Data(), t->GetTrackID(), 
+            t->GetTime(),
+            t->GetInitKineticEne(), 
+            t->GetTotalNph(), t->GetTotalNel());
         if (t->GetInitKineticEne() < 0.01) continue;
         TGraph g; 
         Color_t col = kBlack; 
@@ -243,13 +203,13 @@ void refactor_test_sc(const TString file_path, const int iev)
   for (const auto &scArray : pdsMap) {
     int n_sc = 0; 
 
-    printf("Array: %i - %i hits\n", scArray.first, scArray.second->GetNhits());
-    for (const auto &sc : scArray.second->GetConstSuperCellMap()) {
-      auto n = sc.second->GetNhits(); 
+    printf("Array: %i - %i hits\n", scArray.first, scArray.second.GetNhits());
+    for (const auto &sc : scArray.second.GetConstSuperCellMap()) {
+      auto n = sc.second.GetNhits(); 
       //printf("SC %i recorded %i hits\n", sc.second->GetIdx(), n); 
       n_sc += n;
 
-      for (const auto &h : sc.second->GetConstHits()) {
+      for (const auto &h : sc.second.GetConstHits()) {
         hTime->Fill( h.first, h.second ); 
       }
     }


### PR DESCRIPTION
Event data structure now uses references to static members instead of pointers to play on the safe side of memory management. 
Where this proved particularly inconvenient (i.e. for storing trajectories) I am now using a std::unique_ptr. 

In addition I introduced a small modification to the IonAndScint class that should improve the performance of the simulation. 

Depending on the physics lists used, the simulation requires ~3GB of RAM in standard conditions. Note that using a physics list that does not include HP cross section tables reduces the baseline memory requirement by ~1GB, while using HP cross sections for α,p and other light ions demands ~1GB more. 